### PR TITLE
021 日本酒の好み度

### DIFF
--- a/app/models/sake_log.rb
+++ b/app/models/sake_log.rb
@@ -4,7 +4,7 @@
 #
 #  id             :bigint           not null, primary key
 #  aroma_strength :float            not null
-#  rating         :integer          not null
+#  rating         :integer          default(0), not null
 #  review         :text
 #  taste_strength :float            not null
 #  created_at     :datetime         not null

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -9,8 +9,26 @@
   <% end %>
   <div class="my-5">
     <%= f.label :rating %>
-    <%= f.number_field :rating, step: 1  %>
+    <div class="flex justify-between items-center">
+      <%# 画面左 好み度入力 %>
+      <div class="rating rating-xl flex items-center gap-2">
+        <%# 好み度0(クリア)　%>
+        <%= f.radio_button :rating, 0, class: "rating-hidden", id: "rating-0", aria: { label: "clear" } %>
+
+        <%# 好み度1〜5　%>
+        <% (1..5).each do |i| %>
+          <%= f.radio_button :rating, i, class: "mask mask-star", id: "rating-#{i}", aria: { label: "#{i} star" } %>
+        <% end %>
+      </div>
+
+      <%# 画面右 クリアボタン %>
+      <label for="rating-0" class="cursor-pointer tooltip" data-tip="好み度をクリア">
+        <span class="btn btn-xs btn-secondary">クリア</span>
+      </label>
+    </div>
   </div>
+
+
   <div class="my-5">
     <%= f.label :aroma_strength %>
     <%= f.number_field :aroma_strength, step: 0.1 %>

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -13,11 +13,11 @@
       <%# 画面左 好み度入力 %>
       <div class="rating rating-xl flex items-center gap-2">
         <%# 好み度0(クリア)　%>
-        <%= f.radio_button :rating, 0, class: "rating-hidden", id: "rating-0", aria: { label: "clear" } %>
+        <%= f.radio_button :rating, 0, class: "rating-hidden", id: "rating-0", aria: { label: "clear" } , checked: "checked" %>
 
         <%# 好み度1〜5　%>
         <% (1..5).each do |i| %>
-          <%= f.radio_button :rating, i, class: "mask mask-star", id: "rating-#{i}", aria: { label: "#{i} star" } %>
+          <%= f.radio_button :rating, i, class: "mask mask-star-2 bg-yellow-300", id: "rating-#{i}", aria: { label: "#{i} star" } %>
         <% end %>
       </div>
 

--- a/db/migrate/20250719071724_change_rating_default_on_sake_logs.rb
+++ b/db/migrate/20250719071724_change_rating_default_on_sake_logs.rb
@@ -1,0 +1,5 @@
+class ChangeRatingDefaultOnSakeLogs < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :sake_logs, :rating, from: nil, to: "0"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_13_075644) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_19_071724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "sake_logs", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "sake_id", null: false
-    t.integer "rating", limit: 2, null: false
+    t.integer "rating", limit: 2, default: 0, null: false
     t.float "taste_strength", null: false
     t.float "aroma_strength", null: false
     t.text "review"


### PR DESCRIPTION
## 概要
日本酒新規記録画面の好み度の入力欄を☆で入力

## 関連issue
closes #22 

## やったこと
- 日本酒新規記録画面の好み度の入力欄を☆で選択可能とした
- sake_logsテーブルのratingのデフォルト値を0に設定

## やらないこと
- index画面のratingの☆表示
