### PR TITLE
028 ヘッダーの修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,14 +4,14 @@
     <% unless user_signed_in? %>
       <!-- ログインボタン表示 -->
       <%= link_to new_user_session_path, class: "btn btn-ghost btn-secondary btn-sm md:btn-md flex items-center gap-1" do %>
-        <span><%= t('header.login') %></span>
         <span class="material-symbols-rounded ms-size-20 md:ms-size-24">login</span>
+        <span><%= t('header.login') %></span>
       <% end %>
     <% else %>
       <!-- ログアウトボタン表示 -->
       <%= link_to destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-ghost btn-secondary btn-sm md:btn-md flex items-center gap-1" do %>
-        <span><%= t('header.logout') %></span>
         <span class="material-symbols-rounded ms-size-20 md:ms-size-24">logout</span>
+        <span><%= t('header.logout') %></span>
       <% end %>
     <% end %>
   </div>
@@ -29,9 +29,7 @@
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle btn-secondary">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"> <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /> </svg>
       </div>
-      <ul
-        tabindex="0"
-        class="menu  menu-md md:menu-lg dropdown-content bg-base-100 rounded-box z-10 mt-3 w-52 p-2 shadow">
+      <ul tabindex="-1" class="menu menu-md md:menu-lg dropdown-content bg-base-100 rounded-box z-10 mt-3 w-52 p-2 shadow">
         <li><%= link_to "home", root_path %></li>
       </ul>
     </div>


### PR DESCRIPTION
## 概要
- ヘッダーの固定
- ハンバーガーメニューとログイン・ログアウトボタンの配置入れ替え

## 関連issue
close #160 

## やったこと
- ヘッダーの上部固定
- ハンバーガーメニューとログイン・ログアウトボタンの配置入れ替え
  - ボタンの入れ替え
  - ハンバーガーメニューのメニューをボタンの末端揃えに変更

## やらないこと
なし

## できるようになること(ユーザ目線)
- スクロールしてもヘッダーが残る

## できなくなること(ユーザ目線)
なし

## 影響範囲
なし

## 動作確認とその方法
- スクロールしても上部にヘッダーが固定されていること
- ログイン・ログアウトボタンが左側、ハンバーガーメニューボタンが右側に配置されていること

## その他
なし
