### PR TITLE
033_meta-tagsを利用した動的ページタイトルの表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: "吟ログ",
-      title: "日本酒の簡単メモアプリ",
+      title: content_for?(:title) ? content_for(:title) : "",
       reverse: false,
       charset: "utf-8",
       separator: "|",   # Webサイト名とページタイトルを区切るために使用されるテキスト


### PR DESCRIPTION
# 概要
ページタイトルを動的に変化させる

# 関連issue
close #127 

# やったこと
meta-tagsの設定

# やらないこと
なし

# できるようになること(ユーザ目線)
webブラウザのタブのページタイトルが、動的に変化する

# できなくなること(ユーザ目線)
なし

# 影響範囲
なし

# 動作確認とその方法

- [x] ブラウザのタイトルがページ毎に動的に変わることを確認する

# その他
なし
