### PR TITLE
update: 一覧画面の編集・削除ボタンのサイズ拡大

### DIFF
--- a/app/assets/stylesheets/material_symbols.css
+++ b/app/assets/stylesheets/material_symbols.css
@@ -29,6 +29,12 @@ span.ms-size-24 {
   font-size: 24px;
   font-variation-settings: 'OPSZ' 24;
 }
+
+span.ms-size-32 {
+  font-size: 32px;
+  font-variation-settings: 'OPSZ' 32;
+}
+
 span.ms-size-40 {
   font-size: 40px;
   font-variation-settings: 'OPSZ' 40;

--- a/app/views/sake_logs/_sake_log.html.erb
+++ b/app/views/sake_logs/_sake_log.html.erb
@@ -5,15 +5,15 @@
     <section class="flex justify-between">
       <h2 class="title font-bold text-xl"><%= sake_log.sake.product_name %></h2>
       <%# 各種ボタン %>
-      <div class="buttons">
+      <div class="buttons flex gap-2">
         <% if current_user&.own?(sake_log) %>
           <%# 編集ボタン %>
           <%= link_to edit_sake_log_path(sake_log), id: "button-edit-#{sake_log.id}" do %>
-            <span class="material-symbols-rounded text-primary ms-size-16 md:ms-size-20">edit_square</span>
+            <span class="material-symbols-rounded text-primary ms-size-24">edit_square</span>
           <% end %>
           <%# 削除ボタン %>
           <%= link_to sake_log_path(sake_log), id: "button-delete-#{sake_log.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')} do %>
-            <span class="material-symbols-rounded text-primary ms-size-16 md:ms-size-20">delete</span>
+            <span class="material-symbols-rounded text-primary ms-size-24">delete</span>
           <% end %>
         <% end %>
       </div>

--- a/app/views/timeline/_sake_log.html.erb
+++ b/app/views/timeline/_sake_log.html.erb
@@ -13,7 +13,7 @@
         <% if current_user&.own?(sake_log) %>
           <%# 削除ボタン %>
           <%= link_to sake_log_path(sake_log), id: "button-delete-#{sake_log.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')} do %>
-            <span class="material-symbols-rounded text-primary ms-size-16 md:ms-size-20">delete</span>
+            <span class="material-symbols-rounded text-primary ms-size-24">delete</span>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
画面の編集・削除ボタンのサイズ変更
# やったこと
<!-- 実施内容を簡潔に -->
- アイコンサイズを16px→24pxに変更してタップしやすく
- ボタン間にgap-2を追加して誤操作を防止
- ms-size-32クラスを追加

# やらないこと
<!-- スコープ外の作業 -->
- なし

# できるようになること(ユーザ目線)
- 画面の操作のしやすさが向上

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- なし

# 動作確認とその方法
- [x] 問題なく画面が動作すること

# その他
<!-- 何かあれば -->