### PR TITLE
041 日本酒記録画面の調整

### DIFF
--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -8,7 +8,6 @@
       <%= f.text_field :product_name, class: "input input-primary w-full" %>
     </div>
 
-    <%# TODO:表示の変更 #>
     <%# 好み度 %>
     <div class="w-full md:w-8/12">
       <%= f.label :rating, class: "font-semibold required" %>


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
日本酒記録フォームのレイアウトを調整し、PC画面での表示を改善
# やったこと
<!-- 実施内容を簡潔に -->
- 各入力項目の間隔を gap-4 → gap-6 に変更
- PC画面（md以上）でフォーム幅を 8/12 に制限し、左右中央揃えに変更
- 各入力フィールドの幅指定を親要素に統一（md:w-11/12 → w-full）
- テキスト入力項目の入力欄にprimaryの色を適用

# やらないこと
<!-- スコープ外の作業 -->
- スマホ画面のレイアウト変更（既存のフルワイド表示を維持）

# できるようになること(ユーザ目線)
- 各入力項目の切れ目が認識しやすくなる
- PC画面でフォームが中央に配置され、見やすくなる
- deviseの新規登録画面と統一感のあるレイアウトになる

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- app/views/sake_logs/_form.html.erb（日本酒記録の新規作成・編集フォーム）

# 動作確認とその方法
- [x]  PC画面（768px以上）でフォーム幅が8/12になり中央揃えになること
- [x]  各入力項目の間隔が適切に広がっていること
- [x]  日本酒記録の新規作成が正常に動作すること
- [x]  日本酒記録の編集が正常に動作すること

# その他
<!-- 何かあれば -->
なし

