### PR TITLE
fix: Google Analytics スクリプトタグを head 内に移動

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,16 +15,16 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-  </head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VJVYRQKGYH"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VJVYRQKGYH"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'G-VJVYRQKGYH');
-  </script>
+      gtag('config', 'G-VJVYRQKGYH');
+    </script>
+  </head>
 
   <body class="min-h-screen flex flex-col">
     <%= render "shared/header" %>


### PR DESCRIPTION
# 概要
Google Analytics の script タグが `</head>` の外側（head と body の間）に配置されていたため、HTML 仕様に従い `<head>` 内に移動した。

# 関連issue
なし（軽微な修正のため）

# やったこと
- Google Analytics の script タグを `</head>` の外側から `<head>` 内に移動

# やらないこと
- なし

# できるようになること(ユーザ目線)
- なし（内部的な HTML 構造の修正）

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- `app/views/layouts/application.html.erb`

# 動作確認とその方法
- [x] ブラウザで開発環境にアクセスし、Google Analytics のスクリプトが `<head>` 内に表示されていることを確認

# その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * インストルメンテーション実装の構造を整理しました。マークアップ内の配置とインデンテーションを最適化し、コード品質を向上させました。既存の機能に変更はなく、ユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->