### PR TITLE
fix: ヘッダーのハンバーガーメニューをネイティブbutton要素に置き換え

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,9 +26,9 @@
   <!-- ハンバーガーメニュー -->
   <div class="navbar-end">
     <div class="dropdown dropdown-end">
-      <div tabindex="0" role="button" class="btn btn-ghost btn-circle text-primary md:btn-md">
+      <button type="button" class="btn btn-ghost btn-circle text-primary md:btn-md">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"> <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /> </svg>
-      </div>
+      </button>
       <ul tabindex="-1" class="z-10 p-2 mt-3 w-52 shadow menu menu-md dropdown-content bg-base-300 text-base-content rounded-box md:menu-lg">
         <li><%= link_to "home", root_path %></li>
       </ul>


### PR DESCRIPTION
# 概要
ヘッダーのハンバーガーメニューで使用されている `div[role="button"]` を、ネイティブの `<button>` 要素に置き換える

# 関連issue
なし（軽微な修正のためissue不要）

# やったこと
- ハンバーガーメニューの `<div tabindex="0" role="button">` を `<button type="button">` に置き換え
- 不要になった `tabindex` と `role` 属性を削除

# やらないこと
- `aria-label` のアクセシビリティ対応

# できるようになること(ユーザ目線)
- 見た目・操作感に変化なし（内部的にネイティブ要素になり、キーボード操作やフォーカス管理がブラウザ標準に準拠）

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- `app/views/shared/_header.html.erb`（ハンバーガーメニュー部分のみ）

# 動作確認とその方法
- [x] ハンバーガーメニューをクリックしてドロップダウンが開くことを確認
- [x] キーボード（Tabキー）でメニューボタンにフォーカスが当たることを確認
- [ ] モバイル・PC両方で表示崩れがないことを確認

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ハンバーガーメニューボタンのアクセシビリティを改善し、キーボードナビゲーションとスクリーンリーダーのサポートが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->