### PR TITLE
fix: 編集画面でhidden fieldのbrand_idが復元されない問題を修正

### DIFF
--- a/app/javascript/controllers/brand_autocomplete_controller.js
+++ b/app/javascript/controllers/brand_autocomplete_controller.js
@@ -37,6 +37,7 @@ export default class extends Controller {
   // 編集時に初期値を復元
   restoreInitialValues() {
     if (this.initialBrandIdValue && this.initialBrandIdValue > 0) {
+      this.hiddenBrandIdTarget.value = this.initialBrandIdValue
       this.inputTarget.value = this.initialBrandNameValue
       this.showBreweryDisplay(this.initialBreweryNameValue)
     }


### PR DESCRIPTION
# 概要
close #75

# 関連issue
#75

# やったこと
- 編集画面で `restoreInitialValues()` 実行時に hidden field の `brand_id` が復元されていなかった問題を修正

# やらないこと
- なし

# できるようになること(ユーザ目線)
- 編集画面で銘柄を変更せずに保存した場合、正しく `brand_id` が送信される

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- `app/javascript/controllers/brand_autocomplete_controller.js`

# 動作確認とその方法
- [x] 日本酒記録を新規作成する（銘柄・商品名を選択）
- [x] 編集画面を開き、銘柄を変更せずに保存する
- [x] 保存後、銘柄・商品名・蔵元が正しく表示されることを確認

# その他
CodeRabbit の指摘（`restoreInitialValues` で hidden の brand_id が復元されていない）への対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブランド選択フィールドの初期値復元時に、隠し項目も正しく復元されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->