### PR TITLE
さけのわデータの帰属表示を追加

### DIFF
--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -167,8 +167,9 @@
 
     <%# さけのわデータ帰属表示 %>
     <p class="text-xs text-base-content/50">
-      <%= link_to "さけのわデータ", "https://sakenowa.com",
-          target: "_blank", rel: "noopener noreferrer", class: "link" %>を利用しています
+      <%= t('sake_logs.sakenowa_attribution_html',
+            link: link_to("さけのわデータ", "https://sakenowa.com",
+                  target: "_blank", rel: "noopener noreferrer", class: "link")) %>
     </p>
   </section>
 <% end %>

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -164,5 +164,11 @@
       <%= link_to "一覧に戻る", sake_logs_path, class: "btn btn-outline btn-primary md:btn-wide" %>
       <%= f.submit nil, class: "btn btn-primary md:btn-wide" %>
     </div>
+
+    <%# さけのわデータ帰属表示 %>
+    <p class="text-xs text-base-content/50">
+      <%= link_to "さけのわデータ", "https://sakenowa.com",
+          target: "_blank", rel: "noopener noreferrer", class: "link" %>を利用しています
+    </p>
   </section>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,9 +31,9 @@
       </button>
       <ul tabindex="-1" class="z-10 p-2 mt-3 w-52 shadow menu menu-md dropdown-content bg-base-300 text-base-content rounded-box md:menu-lg">
         <li><%= link_to "home", root_path %></li>
-        <li class="mt-2 menu-title">データについて</li>
+        <li class="mt-2 menu-title"><%= t('header.data_menu_title') %></li>
         <li>
-          <%= link_to "さけのわデータを利用しています", "https://sakenowa.com",
+          <%= link_to t('header.sakenowa_attribution'), "https://sakenowa.com",
               target: "_blank", rel: "noopener noreferrer", class: "text-xs" %>
         </li>
       </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,6 +31,11 @@
       </button>
       <ul tabindex="-1" class="z-10 p-2 mt-3 w-52 shadow menu menu-md dropdown-content bg-base-300 text-base-content rounded-box md:menu-lg">
         <li><%= link_to "home", root_path %></li>
+        <li class="mt-2 menu-title">データについて</li>
+        <li>
+          <%= link_to "さけのわデータを利用しています", "https://sakenowa.com",
+              target: "_blank", rel: "noopener noreferrer", class: "text-xs" %>
+        </li>
       </ul>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,8 @@ ja:
   header:
     login: ログイン
     logout: ログアウト
+    data_menu_title: データについて
+    sakenowa_attribution: さけのわデータを利用しています
   footer:
     home: ホーム
     search: 検索
@@ -34,6 +36,7 @@ ja:
       title: 日本酒記録編集
     index:
       title: マイログ
+    sakenowa_attribution_html: "%{link}を利用しています"
   timeline:
     index:
       title: タイムライン


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
さけのわAPIのデータを利用していることを示す帰属表示を追加し、既存のi18nパターンに合わせて国際化対応を行った。

# 関連issue
<!-- 閉じたいissue -->
なし

# やったこと
<!-- 実施内容を簡潔に -->
- ヘッダーメニューにさけのわデータの帰属表示リンクを追加
- 日本酒記録フォームの末尾にさけのわデータの帰属表示を追加
- ハードコードの日本語を `t()` ヘルパーによるi18nキーに置き換え

# やらないこと
<!-- スコープ外の作業 -->
- フォーム内の既存 日本語ハードコードのi18n対応

# できるようになること(ユーザ目線)
- ヘッダーメニューと日本語記録フォームの末尾に、さけのわサイトへのリンクが表示される

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- ヘッダー
- 日本酒記録の新規作成・編集フォーム

# 動作確認とその方法
- [x] ヘッダーメニューに「データについて」と「さけのわデータを利用しています」が表示される
  - [x] 「さけのわデータを利用しています」をクリックすると https://sakenowa.com が新しいタブで開く
- [x] 日本酒記録フォームの末尾に「さけのわデータを利用しています」が表示される
  - [x] リンクをクリックすると https://sakenowa.com が新しいタブで開く

# その他
<!-- 何かあれば -->
なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フォーム送信画面に「さけのわデータ」の属性表示を追加しました。
  * ヘッダーメニューに「データについて」セクションと「さけのわデータ」への外部リンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->