### PR TITLE
Feature/222 manual brand brewery registration

### DIFF
--- a/app/controllers/api/brands_controller.rb
+++ b/app/controllers/api/brands_controller.rb
@@ -18,7 +18,9 @@ class Api::BrandsController < ApplicationController
         {
           id: brand.id,
           name: brand.name,
+          brewery_id: brand.brewery.id,
           brewery_name: brand.brewery.name,
+          area_id: brand.brewery.area.id,
           area_name: brand.brewery.area.name,
           # 重複銘柄を区別するためのラベル（例: 「赤武 - 赤武酒造（岩手県）」）
           label: "#{brand.name} - #{brand.brewery.name} (#{brand.brewery.area.name})"

--- a/app/controllers/api/breweries_controller.rb
+++ b/app/controllers/api/breweries_controller.rb
@@ -1,0 +1,29 @@
+# 蔵元オートコンプリート検索用APIコントローラ
+class Api::BreweriesController < ApplicationController
+
+  # GET /api/breweries/search?q=朝日
+  # 蔵元名で部分一致検索し、都道府県情報を含むJSONを返す
+  # @return [void] JSON形式で蔵元候補を返す
+  def search
+    query = params[:q].to_s.strip
+
+    if query.blank?
+      render json: { breweries: [] }
+      return
+    end
+
+    breweries = Brewery.search_by_name(query)
+
+    render json: {
+      breweries: breweries.map { |brewery|
+        {
+          id: brewery.id,
+          name: brewery.name,
+          area_name: brewery.area.name,
+          # 重複蔵元を区別するためのラベル（例: 「朝日酒造（新潟県）」）
+          label: "#{brewery.name}（#{brewery.area.name}）"
+        }
+      }
+    }
+  end
+end

--- a/app/controllers/api/breweries_controller.rb
+++ b/app/controllers/api/breweries_controller.rb
@@ -1,6 +1,5 @@
 # 蔵元オートコンプリート検索用APIコントローラ
 class Api::BreweriesController < ApplicationController
-
   # GET /api/breweries/search?q=朝日
   # 蔵元名で部分一致検索し、都道府県情報を含むJSONを返す
   # @return [void] JSON形式で蔵元候補を返す

--- a/app/controllers/api/breweries_controller.rb
+++ b/app/controllers/api/breweries_controller.rb
@@ -19,6 +19,7 @@ class Api::BreweriesController < ApplicationController
         {
           id: brewery.id,
           name: brewery.name,
+          area_id: brewery.area.id,
           area_name: brewery.area.name,
           # 重複蔵元を区別するためのラベル（例: 「朝日酒造（新潟県）」）
           label: "#{brewery.name}（#{brewery.area.name}）"

--- a/app/controllers/sake_logs_controller.rb
+++ b/app/controllers/sake_logs_controller.rb
@@ -51,6 +51,10 @@ class SakeLogsController < ApplicationController
   end
 
   def sake_log_form_params
-    params.require(:sake_log).permit(:rating, :aroma_strength, :taste_strength, :review, :product_name, :brand_id, :sake_id)
+    params.require(:sake_log).permit(
+      :rating, :aroma_strength, :taste_strength, :review,
+      :product_name, :brand_id, :sake_id,
+      :manual_brand_name, :manual_brewery_name, :brewery_id, :area_id, :manual_brand_mode
+    )
   end
 end

--- a/app/controllers/sake_logs_controller.rb
+++ b/app/controllers/sake_logs_controller.rb
@@ -54,7 +54,7 @@ class SakeLogsController < ApplicationController
     params.require(:sake_log).permit(
       :rating, :aroma_strength, :taste_strength, :review,
       :product_name, :brand_id, :sake_id,
-      :manual_brand_name, :manual_brewery_name, :brewery_id, :area_id, :manual_brand_mode
+      :manual_brand_name, :manual_brewery_name, :brewery_id, :area_id
     )
   end
 end

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -149,7 +149,7 @@ class SakeLogForm
   end
 
   # 都道府県名
-  #（通常モード: Area.name、手入力モード: 選択した Area.name）
+  # （通常モード: Area.name、手入力モード: 選択した Area.name）
   # @return [String, nil] 都道府県名（例: 「岩手県」）
   def area_display_name
     if brand_id.present?

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -17,7 +17,6 @@ class SakeLogForm
   attribute :manual_brewery_name, :string
   attribute :brewery_id, :integer           # オートコンプリートで選択した蔵元ID
   attribute :area_id, :integer              # 都道府県ID (蔵元手入力時)
-  attribute :manual_brand_mode, :boolean
 
   # 関連オブジェクト (ゲッターのみ)
   attr_reader :sake_log, :user
@@ -126,42 +125,61 @@ class SakeLogForm
     SakeLog.model_name
   end
 
-  # 銘柄名(オートコンプリート入力欄の初期表示用)
+  # 銘柄名（通常モード: Brand.name、手入力モード: manual_brand_name）
   # @return [String, nil] 銘柄名（例: 「赤武」）
   def brand_display_name
-    return nil if brand_id.blank?
+    return Brand.find_by(id: brand_id)&.name if brand_id.present?
 
-    Brand.find_by(id: brand_id)&.name
+    manual_brand_name
   end
 
-  # 蔵元名
+  # 蔵元名（通常モード: Brewery.name、蔵元選択時: Brewery.name、蔵元手入力時: manual_brewery_name）
   # @return [String, nil] 蔵元名（例: 「赤武酒造」）
   def brewery_display_name
-    return nil if brand_id.blank?
+    if brand_id.present?
+      brand = Brand.includes(:brewery).find_by(id: brand_id)
+      return brand&.brewery&.name
+    end
 
-    brand = Brand.includes(brewery: :area).find_by(id: brand_id)
-    return nil unless brand
+    if brewery_id.present?
+      return Brewery.find_by(id: brewery_id)&.name
+    end
 
-    brand.brewery.name
+    manual_brewery_name
   end
 
   # 都道府県名
+  #（通常モード: Area.name、手入力モード: 選択した Area.name）
   # @return [String, nil] 都道府県名（例: 「岩手県」）
   def area_display_name
-    return nil if brand_id.blank?
+    if brand_id.present?
+      brand = Brand.includes(brewery: :area).find_by(id: brand_id)
+      return brand&.brewery&.area&.name
+    end
 
-    brand = Brand.includes(brewery: :area).find_by(id: brand_id)
-    return nil unless brand
+    if brewery_id.present?
+      brewery = Brewery.includes(:area).find_by(id: brewery_id)
+      return brewery&.area&.name
+    end
 
-    brand.brewery.area.name
+    return Area.find_by(id: area_id)&.name if area_id.present?
+
+    nil
   end
 
   def manual_brand_mode?
-    manual_brand_mode == true
+    brand_id.blank?
   end
 
   def manual_brewery_mode?
     manual_brand_mode? && brewery_id.blank?
+  end
+
+  # 銘柄が確定済みか(商品名入力欄の活性判定に使用)
+  # 通常モードでbrand_id が present、または手入力モードで manual_brand_name が入力済み⇒true
+  # @return [Boolean]
+  def brand_committed?
+    brand_id.present? || manual_brand_name.present?
   end
 
   # 都道府県の選択肢

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -12,6 +12,12 @@ class SakeLogForm
   attribute :aroma_strength, :float
   attribute :taste_strength, :float
   attribute :review, :string
+  # 銘柄手入力モード用の属性
+  attribute :manual_brand_name, :string
+  attribute :manual_brewery_name, :string
+  attribute :brewery_id, :integer           # オートコンプリートで選択した蔵元ID
+  attribute :area_id, :integer              # 都道府県ID (蔵元手入力時)
+  attribute :manual_brand_mode, :boolean
 
   # 関連オブジェクト (ゲッターのみ)
   attr_reader :sake_log, :user
@@ -35,6 +41,11 @@ class SakeLogForm
                               numericality: { greater_than_or_equal_to: SakeLog::AROMA_STRENGTH_MIN,
                                               less_than_or_equal_to: SakeLog::AROMA_STRENGTH_MAX }
   validates :review, length: { maximum: SakeLog::REVIEW_MAX_LENGTH }, allow_blank: true
+  # 銘柄手入力モード時のバリデーション
+  validates :manual_brand_name, presence: true, length: { maximum: Brand::NAME_MAX_LENGTH }, if: :manual_brand_mode?
+  validates :brewery_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :area_id, numericality: { only_integer: true, greater_than: 0 }, if: :manual_brewery_mode?
+  validates :manual_brewery_name, presence: true, length: { maximum: Brewery::NAME_MAX_LENGTH }, if: :manual_brewery_mode?
 
   # コンストラクタ
   # @param attributes [Hash] フォームの属性
@@ -65,6 +76,9 @@ class SakeLogForm
     return false if invalid?
 
     SakeLog.transaction do
+      # 銘柄手入力モード時は Brand/Brewery を先に作成
+      resolve_brand_id! if manual_brand_mode?
+
       # sake_idがある場合は既存レコードを使用、なければ検索・作成
       sake = find_or_initialize_sake
 
@@ -113,25 +127,82 @@ class SakeLogForm
   end
 
   # 銘柄名(オートコンプリート入力欄の初期表示用)
-  # @return [string, nil] 銘柄名（例: 「赤武」）
+  # @return [String, nil] 銘柄名（例: 「赤武」）
   def brand_display_name
     return nil if brand_id.blank?
 
     Brand.find_by(id: brand_id)&.name
   end
 
-  # 蔵元名(蔵元表示エリアの初期表示用)
-  # @return [String, nil] 「赤武酒造（岩手県）」形式の蔵元名
+  # 蔵元名
+  # @return [String, nil] 蔵元名（例: 「赤武酒造」）
   def brewery_display_name
     return nil if brand_id.blank?
 
     brand = Brand.includes(brewery: :area).find_by(id: brand_id)
     return nil unless brand
 
-    "#{brand.brewery.name}（#{brand.brewery.area.name}）"
+    brand.brewery.name
+  end
+
+  # 都道府県名
+  # @return [String, nil] 都道府県名（例: 「岩手県」）
+  def area_display_name
+    return nil if brand_id.blank?
+
+    brand = Brand.includes(brewery: :area).find_by(id: brand_id)
+    return nil unless brand
+
+    brand.brewery.area.name
+  end
+
+  def manual_brand_mode?
+    manual_brand_mode == true
+  end
+
+  def manual_brewery_mode?
+    manual_brand_mode? && brewery_id.blank?
+  end
+
+  def area_options
+    # TODO:実装
   end
 
   private
+
+  # 銘柄手入力モード時に Brand(と必要なら Brewery)を作成し、brand_id をセットする
+  # @return [void]
+  def resolve_brand_id!
+    brewery = find_or_create_brewery!
+    brand = find_or_create_brand!(brewery)
+    self.brand_id = brand.id
+  end
+
+  # 蔵元の検索または作成
+  # brewery_id があれば既存 Brewery を使用
+  # なければ名前+エリアで検索、なければ新規作成。
+  # @return [Brewery] 既存または新規の Brewery レコード
+  def find_or_create_brewery!
+    if brewery_id.present?
+      Brewery.find(brewery_id)
+    else
+      Brewery.find_or_create_by!(
+        name: manual_brewery_name.strip,
+        area_id: area_id
+      )
+    end
+  end
+
+  # 銘柄の検索または作成
+  # 同名+同蔵元の Brand が既にあれば再利用、なければ新規作成
+  # @param brewery [Brewery] 紐づける蔵元
+  # @return [Brand] 既存または新規の Brand レコード
+  def find_or_create_brand!(brewery)
+    Brand.find_or_create_by!(
+      name: manual_brand_name.strip,
+      brewery_id: brewery.id
+    )
+  end
 
   # Sakeの検索または初期化(brand_id, sake_idを考慮)
   # @return [Sake] 既存または、新規のSakeオブジェクト

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -34,8 +34,8 @@ class SakeLogForm
                                       less_than_or_equal_to: SakeLog::RATING_MAX,
                                       allow_nil: true } # nilはpresenceで弾き、numericalityはnil以外のときのみチェック
   validates :taste_strength, presence: true,
-                      numericality: { greater_than_or_equal_to: SakeLog::TASTE_STRENGTH_MIN,
-                                      less_than_or_equal_to: SakeLog::TASTE_STRENGTH_MAX }
+                              numericality: { greater_than_or_equal_to: SakeLog::TASTE_STRENGTH_MIN,
+                                              less_than_or_equal_to: SakeLog::TASTE_STRENGTH_MAX }
   validates :aroma_strength, presence: true,
                               numericality: { greater_than_or_equal_to: SakeLog::AROMA_STRENGTH_MIN,
                                               less_than_or_equal_to: SakeLog::AROMA_STRENGTH_MAX }
@@ -43,7 +43,9 @@ class SakeLogForm
   # 銘柄手入力モード時のバリデーション
   validates :manual_brand_name, presence: true, length: { maximum: Brand::NAME_MAX_LENGTH }, if: :manual_brand_mode?
   validates :brewery_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
-  validates :area_id, numericality: { only_integer: true, greater_than: 0 }, if: :manual_brewery_mode?
+  validates :area_id, presence: { message: "を選択してください" },
+                      numericality: { only_integer: true, greater_than: 0, allow_nil: true },
+                      if: :manual_brewery_mode?
   validates :manual_brewery_name, presence: true, length: { maximum: Brewery::NAME_MAX_LENGTH }, if: :manual_brewery_mode?
 
   # コンストラクタ

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -259,15 +259,34 @@ class SakeLogForm
   end
 
   # モデルのバリデーションエラーをFormObjectに転記する
-  # @param record [ActiveRecord::Base] エラーが発生したレコード（SakeまたはSakeLog）
+  # @param record [ActiveRecord::Base] エラーが発生したレコード（Sake/SakeLog/Brand/Brewery）
   # @return [void]
   def copy_errors_from_record(record)
     record.errors.each do |error|
-      # Sakeのエラーの場合、product_nameに割り当て
-      if record.is_a?(Sake) && error.attribute == :product_name
-        self.errors.add(:product_name, error.message)
-      elsif record.is_a?(SakeLog)
+      case record
+      when Sake
+        # Sakeのエラー: product_name に紐づくものだけFormObjectに転記
+        if error.attribute == :product_name
+          self.errors.add(error.attribute, error.message)
+        end
+      when SakeLog
         self.errors.add(error.attribute, error.message)
+      when Brand
+        if error.attribute == :name
+          self.errors.add(:manual_brand_name, error.message)
+        else
+          # 表示先がない場合は :base に full_message で転記
+          self.errors.add(:base, error.full_message)
+        end
+      when Brewery
+        case error.attribute
+        when :name
+          self.errors.add(:manual_brewery_name, error.message)
+        when :area
+          self.errors.add(:area_id, error.message)
+        else
+          self.errors.add(:base, error.full_message)
+        end
       end
     end
   end

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -88,7 +88,7 @@ class SakeLogForm
       rescue ActiveRecord::RecordNotUnique
         sake = Sake.find_by!(
           product_name: product_name.strip,
-          brand_id: brand_id.presence
+          brand_id: brand_id
         )
       end
 
@@ -209,12 +209,12 @@ class SakeLogForm
   def find_or_initialize_sake
     if sake_id.present?
       # 既存のSakeレコードを使用(オートコンプリートで選択した場合)
-      Sake.find_by!(id: sake_id, brand_id: brand_id.presence)
+      Sake.find_by!(id: sake_id, brand_id: brand_id)
     else
       # 新規のSakeレコードを検索または作成
       Sake.find_or_initialize_by(
         product_name: product_name.strip,
-        brand_id: brand_id.presence
+        brand_id: brand_id
       )
     end
   end

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -164,8 +164,10 @@ class SakeLogForm
     manual_brand_mode? && brewery_id.blank?
   end
 
+  # 都道府県の選択肢
+  # @return [Array<Array<String, Integer>>] [["北海道", 1], ["青森県", 2], ...]
   def area_options
-    # TODO:実装
+    Area.order(:id).pluck(:name, :id)
   end
 
   private

--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -182,6 +182,14 @@ class SakeLogForm
     brand_id.present? || manual_brand_name.present?
   end
 
+  # 蔵元手入力モードかつユーザーが既に入力を開始しているか
+  # 都道府県selectの初期表示判定に使用
+  # 新規フォーム(全て空)ではfalseを返し、selectが表示されないようにする
+  # @return [Boolean]
+  def manual_brewery_input_started?
+    manual_brewery_mode? && manual_brand_name.present?
+  end
+
   # 都道府県の選択肢
   # @return [Array<Array<String, Integer>>] [["北海道", 1], ["青森県", 2], ...]
   def area_options

--- a/app/javascript/controllers/area_display_controller.js
+++ b/app/javascript/controllers/area_display_controller.js
@@ -1,0 +1,117 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="area-display"
+// 都道府県表示コントローラ
+// brand / brewery コントローラのイベントを listen し、
+// 都道府県の input(readonly) / select の切り替えを行う
+
+// 状態パターン:
+// - 初期（未選択）: input(readonly, 空) を表示、select は非活性・非表示
+// - 銘柄選択 / 蔵元選択: input(readonly) に都道府県名を表示
+// - 蔵元手入力モード: select を活性化し、都道府県を選択できるようにする
+export default class extends Controller {
+  static targets = [
+    "input",        // 都道府県 input (readonly 表示用)
+    "select"        // 都道府県 select (手入力モード時に活性化)
+  ]
+
+  static values = {
+    initialBrandId: Number,       // 編集時の初期 brand_id
+    initialBreweryId: Number,     // 編集時の初期 brewery_id
+    initialAreaId: Number,        // 編集時の初期 area_id（蔵元手入力時）
+    initialAreaName: String       // 編集時の初期都道府県名
+  }
+
+  connect() {
+    // brand / brewery コントローラからのイベントを listen
+    this.boundOnBrandSelected = this.onBrandSelected.bind(this)
+    this.boundOnBrandNew = this.onBrandNew.bind(this)
+    this.boundOnBrandCleared = this.onBrandCleared.bind(this)
+    this.boundOnBrewerySelected = this.onBrewerySelected.bind(this)
+    this.boundOnBreweryNew = this.onBreweryNew.bind(this)
+    this.boundOnBreweryCleared = this.onBreweryCleared.bind(this)
+
+    document.addEventListener("brand:selected", this.boundOnBrandSelected)
+    document.addEventListener("brand:new", this.boundOnBrandNew)
+    document.addEventListener("brand:cleared", this.boundOnBrandCleared)
+    document.addEventListener("brewery:selected", this.boundOnBrewerySelected)
+    document.addEventListener("brewery:new", this.boundOnBreweryNew)
+    document.addEventListener("brewery:cleared", this.boundOnBreweryCleared)
+
+    this.restoreInitialValues()
+  }
+
+  disconnect() {
+    document.removeEventListener("brand:selected", this.boundOnBrandSelected)
+    document.removeEventListener("brand:new", this.boundOnBrandNew)
+    document.removeEventListener("brand:cleared", this.boundOnBrandCleared)
+    document.removeEventListener("brewery:selected", this.boundOnBrewerySelected)
+    document.removeEventListener("brewery:new", this.boundOnBreweryNew)
+    document.removeEventListener("brewery:cleared", this.boundOnBreweryCleared)
+  }
+
+  // 編集時や再表示時の初期状態を復元
+  restoreInitialValues() {
+    if (this.initialBrandIdValue > 0 || this.initialBreweryIdValue > 0) {
+      // 銘柄選択済み or 蔵元選択済み → input(readonly) に都道府県名を表示
+      this.showInput(this.initialAreaNameValue || "")
+    } else if (this.initialAreaIdValue > 0) {
+      // 蔵元手入力モード（バリデーションエラー再表示時など）→ select を活性化
+      this.showSelect()
+    } else {
+      // 初期状態: input を非活性・空で表示
+      this.showInput("")
+    }
+  }
+
+  // --- イベントハンドラ ---
+  onBrandSelected(event) {
+    const { areaName } = event.detail
+    this.showInput(areaName || "")
+  }
+
+  onBrandNew() {
+    // 銘柄手入力モードに入った直後。蔵元はまだ未確定なので、都道府県も input を空で保持
+    this.showInput("")
+  }
+
+  onBrandCleared() {
+    // 銘柄がクリアされたら都道府県もリセット（input, 空）
+    this.showInput("")
+  }
+
+  onBrewerySelected(event) {
+    const { areaName } = event.detail
+    this.showInput(areaName || "")
+  }
+
+  onBreweryNew() {
+    // 蔵元手入力モードに入った → 都道府県を select に切り替え
+    this.showSelect()
+  }
+
+  onBreweryCleared() {
+    // 蔵元がクリアされた → 都道府県を input(空) に戻す
+    this.showInput("")
+  }
+
+  // --- 表示切替 ---
+  // input(readonly) を表示し、selectを非表示・非活性化
+  showInput(areaName) {
+    this.inputTarget.value = areaName
+    this.inputTarget.classList.remove("hidden")
+
+    this.selectTarget.classList.add("hidden")
+    this.selectTarget.disabled = true
+    this.selectTarget.value = ""
+  }
+
+  // selectを表示・活性化し、input(readonly)を非表示
+  showSelect() {
+    this.inputTarget.classList.add("hidden")
+    this.inputTarget.value = ""
+
+    this.selectTarget.classList.remove("hidden")
+    this.selectTarget.disabled = false
+  }
+}

--- a/app/javascript/controllers/area_display_controller.js
+++ b/app/javascript/controllers/area_display_controller.js
@@ -72,8 +72,8 @@ export default class extends Controller {
   }
 
   onBrandNew() {
-    // 銘柄手入力モードに入った直後。蔵元はまだ未確定なので、都道府県も input を空で保持
-    this.showInput("")
+    // 銘柄を選択済みから切り替わる場合は brand:cleared が先に発火してリセット済み
+    // 手入力モードで銘柄名を修正した場合は都道府県の表示状態を保持する
   }
 
   onBrandCleared() {

--- a/app/javascript/controllers/area_display_controller.js
+++ b/app/javascript/controllers/area_display_controller.js
@@ -19,7 +19,8 @@ export default class extends Controller {
     initialBrandId: Number,       // 編集時の初期 brand_id
     initialBreweryId: Number,     // 編集時の初期 brewery_id
     initialAreaId: Number,        // 編集時の初期 area_id（蔵元手入力時）
-    initialAreaName: String       // 編集時の初期都道府県名
+    initialAreaName: String,      // 編集時の初期都道府県名
+    manualBreweryMode: Boolean    // 蔵元手入力モードかどうか（バリデーションエラー時の select 復元に使用）
   }
 
   connect() {
@@ -55,7 +56,7 @@ export default class extends Controller {
     if (this.initialBrandIdValue > 0 || this.initialBreweryIdValue > 0) {
       // 銘柄選択済み or 蔵元選択済み → input(readonly) に都道府県名を表示
       this.showInput(this.initialAreaNameValue || "")
-    } else if (this.initialAreaIdValue > 0) {
+    } else if (this.initialAreaIdValue > 0 || this.manualBreweryModeValue) {
       // 蔵元手入力モード（バリデーションエラー再表示時など）→ select を活性化
       this.showSelect()
     } else {

--- a/app/javascript/controllers/brand_autocomplete_controller.js
+++ b/app/javascript/controllers/brand_autocomplete_controller.js
@@ -8,23 +8,17 @@ export default class extends Controller {
   static targets = [
     "input",          // 銘柄名テキスト入力(オートコンプリート対象)
     "hiddenBrandId",
-    "dropdown",
-    "breweryDisplay",  // 蔵元の自動表示エリア (readonly)(通常モードのみ)
-    "manualFields",   // 銘柄手入力モード用フィールド群(蔵元手入力, 都道府県選択)
-    "hiddenManualBrandMode"
+    "dropdown"
   ]
 
   static values = {
     searchUrl: String,          // /api/brands/search
     initialBrandId: Number,     // 編集時の初期brand_id
-    initialBrandName: String,  // 編集時の初期表示銘柄
-    initialBreweryName: String  // 編集時の初期蔵元名
+    initialBrandName: String    // 編集時の初期表示銘柄
   }
 
   connect() {
     this.debounceTimer = null
-    this.manualBrandMode = false
-
     // プルダウン外をクリックするとドロップダウンを閉じるためのリスナー
     this.boundHandleOutsideClick = this.handleOutsideClick.bind(this)
     document.addEventListener("click", this.boundHandleOutsideClick)
@@ -43,7 +37,6 @@ export default class extends Controller {
     if (this.initialBrandIdValue && this.initialBrandIdValue > 0) {
       this.hiddenBrandIdTarget.value = this.initialBrandIdValue
       this.inputTarget.value = this.initialBrandNameValue
-      this.showBreweryDisplay(this.initialBreweryNameValue)
     }
   }
 
@@ -51,7 +44,6 @@ export default class extends Controller {
   onClick() {
     // ドロップダウンが既に表示中なら何もしない
     if (!this.dropdownTarget.classList.contains("hidden")) return
-    if (this.manualBrandMode) return
 
     const query = this.inputTarget.value.trim()
     if (query.length < 1) return
@@ -62,25 +54,16 @@ export default class extends Controller {
   // 入力欄のキー入力ハンドラ (300msのdebounce(チャタリング防止))
   onInput() {
     clearTimeout(this.debounceTimer)
-    
-    // 銘柄手入力モード中はオートコンプリートしない(フリー入力のまま)
     const query = this.inputTarget.value.trim()
 
-    if (this.manualBrandMode) return
-
-    // 銘柄が選択済みだった場合、商品名側もリセットする
+    // 銘柄が選択済みだった場合、brand:cleared を発火して下流にリセットを通知
     const hadSelectedBrand = this.hiddenBrandIdTarget.value !== ""
-
     // 入力が変わったらbrand_idをクリア(再選択を促す)
     this.hiddenBrandIdTarget.value = ""
-    this.hideBreweryDisplay()
 
     // 商品名コントローラに銘柄リセットを通知
     if (hadSelectedBrand) {
-      this.element.dispatchEvent(new CustomEvent("brand-selected", {
-        bubbles: true,
-        detail: { brandId: null }
-      }))
+      this.dispatchBrandCleared()
     }
 
     if (query.length < 1) {
@@ -114,7 +97,7 @@ export default class extends Controller {
     }
   }
 
-  // 候補リストの描画（XSS対策: DOM APIで要素を構築）
+  // 候補リストの描画 + 「新しい銘柄として登録」ボタン
   renderDropdown(brands, query) {
     const ul = document.createElement("ul")
     ul.className = "flex flex-col bg-base-100 border border-base-300 rounded-box shadow-lg w-full max-h-60 overflow-y-auto list-none p-2"
@@ -127,8 +110,10 @@ export default class extends Controller {
       button.dataset.action = "click->brand-autocomplete#selectBrand"
       button.dataset.brandId = brand.id
       button.dataset.brandName = brand.name
-      button.dataset.brandLabel = brand.label
+      button.dataset.breweryId = brand.brewery_id
       button.dataset.breweryName = brand.brewery_name
+      button.dataset.areaId = brand.area_id
+      button.dataset.areaName = brand.area_name
       button.textContent = brand.label
       li.appendChild(button)
       ul.appendChild(li)
@@ -140,8 +125,8 @@ export default class extends Controller {
       const newButton = document.createElement("button")
       newButton.type = "button"
       newButton.className = "w-full text-left px-4 py-2 hover:bg-base-200 text-base-content/60 cursor-pointer"
-      newButton.dataset.action = "click->brand-autocomplete#selectManualBrandMode"
-      newButton.textContent = "該当する銘柄がない（手入力する）"
+      newButton.dataset.action = "click->brand-autocomplete#selectNewBrand"
+      newButton.textContent = "新しい銘柄として登録"
       newLi.appendChild(newButton)
       ul.appendChild(newLi)
     }
@@ -154,76 +139,45 @@ export default class extends Controller {
   // 銘柄候補を選択したとき
   selectBrand(event) {
     const button = event.currentTarget
-    const brandId = button.dataset.brandId
-    const breweryName = button.dataset.breweryName
+    const brandId = parseInt(button.dataset.brandId, 10)
+    const breweryId = parseInt(button.dataset.breweryId, 10)
+    const areaId = parseInt(button.dataset.areaId, 10)
 
     // hidden フィールドにbrand_idをセット
     this.hiddenBrandIdTarget.value = brandId
-
     // 入力欄に銘柄を表示
     this.inputTarget.value = button.dataset.brandName
 
-    this.exitManualBrandMode()
-
-    // 蔵元を自動表示
-    this.showBreweryDisplay(breweryName)
-
     this.closeDropdown()
 
-    // 商品名コントローラにbrand_idの変更を通知(CustomEvent)
-    this.element.dispatchEvent(new CustomEvent("brand-selected", {
-      bubbles: true,
-      detail: { brandId: parseInt(brandId, 10) }
+    // 下流コントローラに銘柄選択を通知
+    document.dispatchEvent(new CustomEvent("brand:selected", {
+      detail: {
+        brandId,
+        brandName: button.dataset.brandName,
+        breweryId,
+        breweryName: button.dataset.breweryName,
+        areaId,
+        areaName: button.dataset.areaName
+      }
     }))
   }
 
-  selectManualBrandMode() {
-    this.manualBrandMode = true
-    this.hiddenManualBrandModeTarget.value = "true"
-    // brand_id をクリア（銘柄手入力時は保存ロジックで Brand を作成する）
+  selectNewBrand() {
+    // brand_id をクリア（保存時に manual_brand_name から Brand を作成する）
     this.hiddenBrandIdTarget.value = ""
 
-    // 蔵元の readonly 表示を非表示にし、銘柄手入力モード用フィールドを表示
-    this.hideBreweryDisplay()
-    this.showManualFields()
-
     this.closeDropdown()
 
-    // 商品名コントローラに銘柄リセットを通知
-    this.element.dispatchEvent(new CustomEvent("brand-selected", {
-      bubbles: true,
-      detail: { brandId: null, manualBrandMode: true }
+    // 下流コントローラに「新規登録モード」を通知
+    document.dispatchEvent(new CustomEvent("brand:new", {
+      detail: { brandName: this.inputTarget.value.trim() }
     }))
   }
 
-  exitManualBrandMode() {
-    this.manualBrandMode = false
-    this.hiddenManualBrandModeTarget.value = ""
-    this.hideManualFields()
-  }
-
-  // --- 蔵元表示の切り替え ---
-
-  // 蔵元の読み取り専用フィールドに値をセットする
-  showBreweryDisplay(text) {
-    this.breweryDisplayTarget.value = text
-    this.breweryDisplayTarget.parentElement.classList.remove("hidden")
-  }
-
-  // 蔵元の読み取り専用フィールドをクリアする
-  hideBreweryDisplay() {
-    this.breweryDisplayTarget.value = ""
-    this.breweryDisplayTarget.parentElement.classList.add("hidden")
-  }
-
-  // 銘柄手入力モード用フィールド群の表示
-  showManualFields() {
-    this.manualFieldsTarget.classList.remove("hidden")
-  }
-
-  // 銘柄手入力モード用フィールドの非表示
-  hideManualFields() {
-    this.manualFieldsTarget.classList.add("hidden")
+  // 銘柄がクリアされたことを通知（下流コントローラ向け）
+  dispatchBrandCleared() {
+    document.dispatchEvent(new CustomEvent("brand:cleared", { detail: {} }))
   }
 
   // ---　ドロップダウン制御 ---

--- a/app/javascript/controllers/brand_autocomplete_controller.js
+++ b/app/javascript/controllers/brand_autocomplete_controller.js
@@ -7,9 +7,11 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [
     "input",          // 銘柄名テキスト入力(オートコンプリート対象)
-    "hiddenBrandId",  // brand_id の hidden フィールド
-    "dropdown",       // 候補リストのドロップダウン
-    "breweryDisplay"  // 蔵元の自動表示エリア (readonly)
+    "hiddenBrandId",
+    "dropdown",
+    "breweryDisplay",  // 蔵元の自動表示エリア (readonly)(通常モードのみ)
+    "manualFields",   // 銘柄手入力モード用フィールド群(蔵元手入力, 都道府県選択)
+    "hiddenManualBrandMode"
   ]
 
   static values = {
@@ -21,6 +23,8 @@ export default class extends Controller {
 
   connect() {
     this.debounceTimer = null
+    this.manualBrandMode = false
+
     // プルダウン外をクリックするとドロップダウンを閉じるためのリスナー
     this.boundHandleOutsideClick = this.handleOutsideClick.bind(this)
     document.addEventListener("click", this.boundHandleOutsideClick)
@@ -47,6 +51,7 @@ export default class extends Controller {
   onClick() {
     // ドロップダウンが既に表示中なら何もしない
     if (!this.dropdownTarget.classList.contains("hidden")) return
+    if (this.manualBrandMode) return
 
     const query = this.inputTarget.value.trim()
     if (query.length < 1) return
@@ -57,7 +62,11 @@ export default class extends Controller {
   // 入力欄のキー入力ハンドラ (300msのdebounce(チャタリング防止))
   onInput() {
     clearTimeout(this.debounceTimer)
+    
+    // 銘柄手入力モード中はオートコンプリートしない(フリー入力のまま)
     const query = this.inputTarget.value.trim()
+
+    if (this.manualBrandMode) return
 
     // 銘柄が選択済みだった場合、商品名側もリセットする
     const hadSelectedBrand = this.hiddenBrandIdTarget.value !== ""
@@ -99,14 +108,14 @@ export default class extends Controller {
       if (!response.ok) return
 
       const data = await response.json()
-      this.renderDropdown(data.brands)
+      this.renderDropdown(data.brands, query)
     } catch (error) {
       console.error("銘柄検索エラー:", error)
     }
   }
 
   // 候補リストの描画（XSS対策: DOM APIで要素を構築）
-  renderDropdown(brands) {
+  renderDropdown(brands, query) {
     const ul = document.createElement("ul")
     ul.className = "flex flex-col bg-base-100 border border-base-300 rounded-box shadow-lg w-full max-h-60 overflow-y-auto list-none p-2"
 
@@ -119,11 +128,23 @@ export default class extends Controller {
       button.dataset.brandId = brand.id
       button.dataset.brandName = brand.name
       button.dataset.brandLabel = brand.label
-      button.dataset.breweryName = `${brand.brewery_name}（${brand.area_name}）`
+      button.dataset.breweryName = brand.brewery_name
       button.textContent = brand.label
       li.appendChild(button)
       ul.appendChild(li)
     })
+
+    // 「該当する銘柄がない」オプションを末尾に追加
+    if (query) {
+      const newLi = document.createElement("li")
+      const newButton = document.createElement("button")
+      newButton.type = "button"
+      newButton.className = "w-full text-left px-4 py-2 hover:bg-base-200 text-base-content/60 cursor-pointer"
+      newButton.dataset.action = "click->brand-autocomplete#selectManualBrandMode"
+      newButton.textContent = "該当する銘柄がない（手入力する）"
+      newLi.appendChild(newButton)
+      ul.appendChild(newLi)
+    }
 
     this.dropdownTarget.innerHTML = ""
     this.dropdownTarget.appendChild(ul)
@@ -142,6 +163,8 @@ export default class extends Controller {
     // 入力欄に銘柄を表示
     this.inputTarget.value = button.dataset.brandName
 
+    this.exitManualBrandMode()
+
     // 蔵元を自動表示
     this.showBreweryDisplay(breweryName)
 
@@ -154,16 +177,53 @@ export default class extends Controller {
     }))
   }
 
+  selectManualBrandMode() {
+    this.manualBrandMode = true
+    this.hiddenManualBrandModeTarget.value = "true"
+    // brand_id をクリア（銘柄手入力時は保存ロジックで Brand を作成する）
+    this.hiddenBrandIdTarget.value = ""
+
+    // 蔵元の readonly 表示を非表示にし、銘柄手入力モード用フィールドを表示
+    this.hideBreweryDisplay()
+    this.showManualFields()
+
+    this.closeDropdown()
+
+    // 商品名コントローラに銘柄リセットを通知
+    this.element.dispatchEvent(new CustomEvent("brand-selected", {
+      bubbles: true,
+      detail: { brandId: null, manualBrandMode: true }
+    }))
+  }
+
+  exitManualBrandMode() {
+    this.manualBrandMode = false
+    this.hiddenManualBrandModeTarget.value = ""
+    this.hideManualFields()
+  }
+
   // --- 蔵元表示の切り替え ---
 
   // 蔵元の読み取り専用フィールドに値をセットする
   showBreweryDisplay(text) {
     this.breweryDisplayTarget.value = text
+    this.breweryDisplayTarget.parentElement.classList.remove("hidden")
   }
 
   // 蔵元の読み取り専用フィールドをクリアする
   hideBreweryDisplay() {
     this.breweryDisplayTarget.value = ""
+    this.breweryDisplayTarget.parentElement.classList.add("hidden")
+  }
+
+  // 銘柄手入力モード用フィールド群の表示
+  showManualFields() {
+    this.manualFieldsTarget.classList.remove("hidden")
+  }
+
+  // 銘柄手入力モード用フィールドの非表示
+  hideManualFields() {
+    this.manualFieldsTarget.classList.add("hidden")
   }
 
   // ---　ドロップダウン制御 ---

--- a/app/javascript/controllers/brewery_autocomplete_controller.js
+++ b/app/javascript/controllers/brewery_autocomplete_controller.js
@@ -81,10 +81,8 @@ export default class extends Controller {
     this.closeDropdown()
   }
 
-  // 銘柄手入力時：蔵元をクリアして編集可能に
+  // 銘柄手入力時：蔵元を編集可能にする
   onBrandNew() {
-    this.inputTarget.value = ""
-    this.hiddenBreweryIdTarget.value = ""
     this.enableInput()
     this.closeDropdown()
   }

--- a/app/javascript/controllers/brewery_autocomplete_controller.js
+++ b/app/javascript/controllers/brewery_autocomplete_controller.js
@@ -54,7 +54,7 @@ export default class extends Controller {
     if (this.initialBrandIdValue && this.initialBrandIdValue > 0) {
       // 銘柄選択済み
       this.inputTarget.value = this.initialBreweryNameValue
-      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue || "" // id=0(無効な値)なら""を設定
+      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue || "" // brewery_id=0(無効な値)なら""を設定
       this.disableInput()
     } else if (this.initialBreweryIdValue && this.initialBreweryIdValue > 0) {
       // 銘柄手入力中 + 蔵元選択済み

--- a/app/javascript/controllers/brewery_autocomplete_controller.js
+++ b/app/javascript/controllers/brewery_autocomplete_controller.js
@@ -8,26 +8,30 @@ export default class extends Controller {
   static targets = [
     "input",
     "hiddenBreweryId",
-    "dropdown",
-    "areaDisplay",
-    "areaSelect",       // 都道府県の select ボックス（蔵元手入力時に表示）
-    "areaSelectWrapper" // 都道府県 select のラッパー(表示/非表示切り替え用)
+    "dropdown"
   ]
 
   static values = {
-    searchUrl: String,
-    initialBreweryId: Number,     // 編集時の初期brewery_id
-    initialBreweryName: String,   // 編集時の初期蔵元名
-    initialAreaName: String       // 編集時の初期都道府県名
+    searchUrl: String,            // /api/breweries/search
+    initialBrandId: Number,       // 編集時の初期 brand_id
+    initialBreweryId: Number,     // 編集時の初期 brewery_id
+    initialBreweryName: String    // 編集時の初期蔵元名
   }
 
   connect() {
     this.debounceTimer = null
-    this.manualBreweryMode = false  // 蔵元手入力モードフラグ
 
     // プルダウン外クリック時にドロップダウンを閉じるためのリスナー
     this.boundHandleOutsideClick = this.handleOutsideClick.bind(this)
     document.addEventListener("click", this.boundHandleOutsideClick)
+
+    // brand-autocompleteからのイベントを監視
+    this.boundOnBrandSelected = this.onBrandSelected.bind(this)
+    this.boundOnBrandNew = this.onBrandNew.bind(this)
+    this.boundOnBrandCleared = this.onBrandCleared.bind(this)
+    document.addEventListener("brand:selected", this.boundOnBrandSelected)
+    document.addEventListener("brand:new", this.boundOnBrandNew)
+    document.addEventListener("brand:cleared", this.boundOnBrandCleared)
 
     // 編集時: 初期値を復元
     this.restoreInitialValues()
@@ -35,23 +39,69 @@ export default class extends Controller {
 
   disconnect() {
     document.removeEventListener("click", this.boundHandleOutsideClick)
+    document.removeEventListener("brand:selected", this.boundOnBrandSelected)
+    document.removeEventListener("brand:new", this.boundOnBrandNew)
+    document.removeEventListener("brand:cleared", this.boundOnBrandCleared)
     clearTimeout(this.debounceTimer)
   }
 
   // 編集時に初期値を復元
+  // - 銘柄選択済み(brand_id > 0): 蔵元名と brewery_id を復元、入力欄は非活性
+  // - 銘柄手入力中 + 蔵元選択済み: 蔵元名と brewery_id を復元、入力欄は活性
+  // - 銘柄手入力中 + 蔵元手入力: 蔵元名を復元、入力欄は活性
+  // - 未入力: 入力欄は非活性
   restoreInitialValues() {
-    if (this.initialBreweryIdValue && this.initialBreweryIdValue > 0) {
-      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue
+    if (this.initialBrandIdValue && this.initialBrandIdValue > 0) {
+      // 銘柄選択済み
       this.inputTarget.value = this.initialBreweryNameValue
-      this.showAreaDisplay(this.initialAreaNameValue)
+      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue || "" // id=0(無効な値)なら""を設定
+      this.disableInput()
+    } else if (this.initialBreweryIdValue && this.initialBreweryIdValue > 0) {
+      // 銘柄手入力中 + 蔵元選択済み
+      this.inputTarget.value = this.initialBreweryNameValue
+      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue
+      this.enableInput()
+    } else if (this.initialBreweryNameValue) {
+      // 銘柄手入力中 + 蔵元手入力
+      this.inputTarget.value = this.initialBreweryNameValue
+      this.hiddenBreweryIdTarget.value = ""
+      this.enableInput()
+    } else {
+      // 未入力
+      this.disableInput()
     }
+  }
+
+  // 銘柄選択時：蔵元を自動表示してreadonlyに
+  onBrandSelected(event) {
+    const { breweryId, breweryName } = event.detail
+    this.inputTarget.value = breweryName || ""
+    this.hiddenBreweryIdTarget.value = breweryId || ""
+    this.disableInput()
+    this.closeDropdown()
+  }
+
+  // 銘柄手入力時：蔵元をクリアして編集可能に
+  onBrandNew() {
+    this.inputTarget.value = ""
+    this.hiddenBreweryIdTarget.value = ""
+    this.enableInput()
+    this.closeDropdown()
+  }
+
+  // 銘柄クリア時：蔵元をクリアしてreadonlyに
+  onBrandCleared() {
+    this.inputTarget.value = ""
+    this.hiddenBreweryIdTarget.value = ""
+    this.disableInput()
+    this.closeDropdown()
+    this.dispatchBreweryCleared()
   }
 
   // 入力欄クリック時に入力済みテキストで検索
   onClick() {
+    if (this.inputTarget.disabled) return
     if (!this.dropdownTarget.classList.contains("hidden")) return
-    // 蔵元手入力モード中はオートコンプリートしない
-    if (this.manualBreweryMode) return
 
     const query = this.inputTarget.value.trim()
     if (query.length < 1) return
@@ -61,15 +111,18 @@ export default class extends Controller {
 
   // 入力欄のキー入力ハンドラ
   onInput() {
+    if (this.inputTarget.disabled) return
+
     clearTimeout(this.debounceTimer)
     const query = this.inputTarget.value.trim()
 
-    // 蔵元手入力モード中はオートコンプリートしない
-    if (this.manualBreweryMode) return
-
-    // 入力が変わったらbrewery_idをクリア(再選択を促す)
+    // 蔵元選択済みだった場合は、brewery:clearedを発火
+    const hadSelectedBrewery = this.hiddenBreweryIdTarget.value !== ""
     this.hiddenBreweryIdTarget.value = ""
-    this.hideAreaDisplay()
+
+    if (hadSelectedBrewery) {
+      this.dispatchBreweryCleared()
+    }
 
     if (query.length < 1) {
       this.closeDropdown()
@@ -114,20 +167,21 @@ export default class extends Controller {
       button.dataset.action = "click->brewery-autocomplete#selectBrewery"
       button.dataset.breweryId = brewery.id
       button.dataset.breweryName = brewery.name
+      button.dataset.areaId = brewery.area_id
       button.dataset.areaName = brewery.area_name
       button.textContent = brewery.label
       li.appendChild(button)
       ul.appendChild(li)
     })
 
-    // 「該当する蔵元がない」オプションを追加
+    // 「新しい蔵元として登録」オプションを末尾に追加
     if (query) {
       const newLi = document.createElement("li")
       const newButton = document.createElement("button")
       newButton.type = "button"
       newButton.className = "w-full text-left px-4 py-2 hover:bg-base-200 text-base-content/60 cursor-pointer"
-      newButton.dataset.action = "click->brewery-autocomplete#selectManualBrewery"
-      newButton.textContent = "該当する蔵元がない（手入力する）"
+      newButton.dataset.action = "click->brewery-autocomplete#selectNewBrewery"
+      newButton.textContent = "新しい蔵元として登録"
       newLi.appendChild(newButton)
       ul.appendChild(newLi)
     }
@@ -140,59 +194,54 @@ export default class extends Controller {
   // 蔵元候補を選択したとき
   selectBrewery(event) {
     const button = event.currentTarget
-    const breweryId = button.dataset.breweryId
-    const breweryName = button.dataset.breweryName
-    const areaName = button.dataset.areaName
+    const breweryId = parseInt(button.dataset.breweryId, 10)
+    const areaId = parseInt(button.dataset.areaId, 10)
 
     // hidden フィールドにbrewery_idをセット
     this.hiddenBreweryIdTarget.value = breweryId
     // 入力欄に蔵元名表示
-    this.inputTarget.value = breweryName
-    // 都道府県を自動表示
-    this.showAreaDisplay(areaName)
-    this.hideAreaSelect()
+    this.inputTarget.value = button.dataset.breweryName
 
-    this.manualBreweryMode = false
     this.closeDropdown()
+
+    document.dispatchEvent(new CustomEvent("brewery:selected", {
+      detail: {
+        breweryId,
+        breweryName: button.dataset.breweryName,
+        areaId,
+        areaName: button.dataset.areaName
+      }
+    }))
   }
 
-  // 「該当する蔵元がない」を選択したとき → 蔵元手入力モードに切り替え
-  selectManualBrewery() {
-    this.manualBreweryMode = true
+  // 「新しい蔵元として登録」を選択 → brewery:newを発火
+  selectNewBrewery() {
     // brewery_idをクリア
     this.hiddenBreweryIdTarget.value = ""
-
-    // 都道府県の readonly表示を非表示にし、selectボックスを表示
-    this.hideAreaDisplay()
-    this.showAreaSelect()
-
     this.closeDropdown()
-    this.inputTarget.focus()
+
+    document.dispatchEvent(new CustomEvent("brewery:new", {
+      detail: { breweryName: this.inputTarget.value.trim() }
+    }))
   }
 
-  // --- 都道府県表示の切り替え ---
-
-  // 都道府県の読み取り専用フィールドに値をセットする
-  showAreaDisplay(text) {
-    this.areaDisplayTarget.value = text
-    this.areaDisplayTarget.classList.remove("hidden")
+  // 蔵元クリアを下流に通知
+  dispatchBreweryCleared() {
+    document.dispatchEvent(new CustomEvent("brewery:cleared", { detail: {} }))
   }
 
-  // 都道府県の読み取り専用フィールドをクリアする
-  hideAreaDisplay() {
-    this.areaDisplayTarget.value = ""
-    this.areaDisplayTarget.classList.add("hidden")
+  // 入力欄を活性化
+  enableInput() {
+    this.inputTarget.disabled = false
+    this.inputTarget.classList.remove("bg-base-200", "text-base-content/70")
+    this.inputTarget.classList.add("input-primary")
   }
 
-  // 都道府県のselectボックスを表示する
-  showAreaSelect() {
-    this.areaSelectWrapperTarget.classList.remove("hidden")
-  }
-
-  // 都道府県のselectボックスを非表示にする
-  hideAreaSelect() {
-    this.areaSelectWrapperTarget.classList.add("hidden")
-    this.areaSelectTarget.value = ""
+  // 入力欄を非活性化
+  disableInput() {
+    this.inputTarget.disabled = true
+    this.inputTarget.classList.add("bg-base-200", "text-base-content/70")
+    this.inputTarget.classList.remove("input-primary")
   }
 
   // --- ドロップダウン制御 ---

--- a/app/javascript/controllers/brewery_autocomplete_controller.js
+++ b/app/javascript/controllers/brewery_autocomplete_controller.js
@@ -1,0 +1,210 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="brewery-autocomplete"
+// 銘柄手入力モード時に蔵元名を入力すると、既存の蔵元マスタから候補を表示する
+// 候補選択時に都道府県を自動表示し、brewery_id をセットする
+// 「該当する蔵元がない」を選択すると蔵元手入力モード（蔵元手入力 + 都道府県選択）に切り替わる
+export default class extends Controller {
+  static targets = [
+    "input",
+    "hiddenBreweryId",
+    "dropdown",
+    "areaDisplay",
+    "areaSelect",       // 都道府県の select ボックス（蔵元手入力時に表示）
+    "areaSelectWrapper" // 都道府県 select のラッパー(表示/非表示切り替え用)
+  ]
+
+  static values = {
+    searchUrl: String,
+    initialBreweryId: Number,     // 編集時の初期brewery_id
+    initialBreweryName: String,   // 編集時の初期蔵元名
+    initialAreaName: String       // 編集時の初期都道府県名
+  }
+
+  connect() {
+    this.debounceTimer = null
+    this.manualBreweryMode = false  // 蔵元手入力モードフラグ
+
+    // プルダウン外クリック時にドロップダウンを閉じるためのリスナー
+    this.boundHandleOutsideClick = this.handleOutsideClick.bind(this)
+    document.addEventListener("click", this.boundHandleOutsideClick)
+
+    // 編集時: 初期値を復元
+    this.restoreInitialValues()
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundHandleOutsideClick)
+    clearTimeout(this.debounceTimer)
+  }
+
+  // 編集時に初期値を復元
+  restoreInitialValues() {
+    if (this.initialBreweryIdValue && this.initialBreweryIdValue > 0) {
+      this.hiddenBreweryIdTarget.value = this.initialBreweryIdValue
+      this.inputTarget.value = this.initialBreweryNameValue
+      this.showAreaDisplay(this.initialAreaNameValue)
+    }
+  }
+
+  // 入力欄クリック時に入力済みテキストで検索
+  onClick() {
+    if (!this.dropdownTarget.classList.contains("hidden")) return
+    // 蔵元手入力モード中はオートコンプリートしない
+    if (this.manualBreweryMode) return
+
+    const query = this.inputTarget.value.trim()
+    if (query.length < 1) return
+
+    this.searchBreweries(query)
+  }
+
+  // 入力欄のキー入力ハンドラ
+  onInput() {
+    clearTimeout(this.debounceTimer)
+    const query = this.inputTarget.value.trim()
+
+    // 蔵元手入力モード中はオートコンプリートしない
+    if (this.manualBreweryMode) return
+
+    // 入力が変わったらbrewery_idをクリア(再選択を促す)
+    this.hiddenBreweryIdTarget.value = ""
+    this.hideAreaDisplay()
+
+    if (query.length < 1) {
+      this.closeDropdown()
+      return
+    }
+
+    // 300ms入力が止まったら検索
+    this.debounceTimer = setTimeout(() => {
+      this.searchBreweries(query)
+    }, 300)
+  }
+
+  async searchBreweries(query) {
+    try {
+      const url = new URL(this.searchUrlValue, window.location.origin)
+      url.searchParams.set("q", query)
+
+      const response = await fetch(url, {
+        headers: { "Accept": "application/json" },
+        credentials: "same-origin"
+      })
+
+      if (!response.ok) return
+
+      const data = await response.json()
+      this.renderDropdown(data.breweries, query)
+    } catch (error) {
+      console.error("蔵元検索エラー:", error)
+    }
+  }
+
+  // 候補リストの描画
+  renderDropdown(breweries, query) {
+    const ul = document.createElement("ul")
+    ul.className = "flex flex-col bg-base-100 border border-base-300 rounded-box shadow-lg w-full max-h-60 overflow-y-auto list-none p-2"
+
+    breweries.forEach(brewery => {
+      const li = document.createElement("li")
+      const button = document.createElement("button")
+      button.type = "button"
+      button.className = "w-full text-left px-4 py-2 hover:bg-base-200 cursor-pointer"
+      button.dataset.action = "click->brewery-autocomplete#selectBrewery"
+      button.dataset.breweryId = brewery.id
+      button.dataset.breweryName = brewery.name
+      button.dataset.areaName = brewery.area_name
+      button.textContent = brewery.label
+      li.appendChild(button)
+      ul.appendChild(li)
+    })
+
+    // 「該当する蔵元がない」オプションを追加
+    if (query) {
+      const newLi = document.createElement("li")
+      const newButton = document.createElement("button")
+      newButton.type = "button"
+      newButton.className = "w-full text-left px-4 py-2 hover:bg-base-200 text-base-content/60 cursor-pointer"
+      newButton.dataset.action = "click->brewery-autocomplete#selectManualBrewery"
+      newButton.textContent = "該当する蔵元がない（手入力する）"
+      newLi.appendChild(newButton)
+      ul.appendChild(newLi)
+    }
+
+    this.dropdownTarget.innerHTML = ""
+    this.dropdownTarget.appendChild(ul)
+    this.dropdownTarget.classList.remove("hidden")
+  }
+
+  // 蔵元候補を選択したとき
+  selectBrewery(event) {
+    const button = event.currentTarget
+    const breweryId = button.dataset.breweryId
+    const breweryName = button.dataset.breweryName
+    const areaName = button.dataset.areaName
+
+    // hidden フィールドにbrewery_idをセット
+    this.hiddenBreweryIdTarget.value = breweryId
+    // 入力欄に蔵元名表示
+    this.inputTarget.value = breweryName
+    // 都道府県を自動表示
+    this.showAreaDisplay(areaName)
+    this.hideAreaSelect()
+
+    this.manualBreweryMode = false
+    this.closeDropdown()
+  }
+
+  // 「該当する蔵元がない」を選択したとき → 蔵元手入力モードに切り替え
+  selectManualBrewery() {
+    this.manualBreweryMode = true
+    // brewery_idをクリア
+    this.hiddenBreweryIdTarget.value = ""
+
+    // 都道府県の readonly表示を非表示にし、selectボックスを表示
+    this.hideAreaDisplay()
+    this.showAreaSelect()
+
+    this.closeDropdown()
+    this.inputTarget.focus()
+  }
+
+  // --- 都道府県表示の切り替え ---
+
+  // 都道府県の読み取り専用フィールドに値をセットする
+  showAreaDisplay(text) {
+    this.areaDisplayTarget.value = text
+    this.areaDisplayTarget.classList.remove("hidden")
+  }
+
+  // 都道府県の読み取り専用フィールドをクリアする
+  hideAreaDisplay() {
+    this.areaDisplayTarget.value = ""
+    this.areaDisplayTarget.classList.add("hidden")
+  }
+
+  // 都道府県のselectボックスを表示する
+  showAreaSelect() {
+    this.areaSelectWrapperTarget.classList.remove("hidden")
+  }
+
+  // 都道府県のselectボックスを非表示にする
+  hideAreaSelect() {
+    this.areaSelectWrapperTarget.classList.add("hidden")
+    this.areaSelectTarget.value = ""
+  }
+
+  // --- ドロップダウン制御 ---
+  closeDropdown() {
+    this.dropdownTarget.classList.add("hidden")
+    this.dropdownTarget.innerHTML = ""
+  }
+
+  // コントローラ外クリックでドロップダウンを閉じる
+  handleOutsideClick(event) {
+    if (!this.dropdownTarget.contains(event.target) && !this.inputTarget.contains(event.target)) {
+      this.closeDropdown()
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import AreaDisplayController from "./area_display_controller"
+application.register("area-display", AreaDisplayController)
+
 import BrandAutocompleteController from "./brand_autocomplete_controller"
 application.register("brand-autocomplete", BrandAutocompleteController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import BrandAutocompleteController from "./brand_autocomplete_controller"
 application.register("brand-autocomplete", BrandAutocompleteController)
 
+import BreweryAutocompleteController from "./brewery_autocomplete_controller"
+application.register("brewery-autocomplete", BreweryAutocompleteController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/javascript/controllers/product_name_autocomplete_controller.js
+++ b/app/javascript/controllers/product_name_autocomplete_controller.js
@@ -26,7 +26,11 @@ export default class extends Controller {
 
     // 銘柄選択イベントをリスナー登録
     this.boundOnBrandSelected = this.onBrandSelected.bind(this)
-    document.addEventListener("brand-selected", this.boundOnBrandSelected)
+    this.boundOnBrandNew = this.onBrandNew.bind(this)
+    this.boundOnBrandCleared = this.onBrandCleared.bind(this)
+    document.addEventListener("brand:selected", this.boundOnBrandSelected)
+    document.addEventListener("brand:new", this.boundOnBrandNew)
+    document.addEventListener("brand:cleared", this.boundOnBrandCleared)
 
     // 編集時: 初期値を復元
     this.restoreInitialValues()
@@ -34,7 +38,9 @@ export default class extends Controller {
 
   disconnect() {
     document.removeEventListener("click", this.boundHandleOutsideClick)
-    document.removeEventListener("brand-selected", this.boundOnBrandSelected)
+    document.removeEventListener("brand:selected", this.boundOnBrandSelected)
+    document.removeEventListener("brand:new", this.boundOnBrandNew)
+    document.removeEventListener("brand:cleared", this.boundOnBrandCleared)
     clearTimeout(this.debounceTimer)
   }
 
@@ -52,7 +58,7 @@ export default class extends Controller {
     }
   }
 
-  // 銘柄選択イベントのハンドラ(brand-autocompleteコントローラから受け取る)
+  // 銘柄選択 → brand_id をセットし入力欄を有効化
   onBrandSelected(event) {
     const { brandId } = event.detail
     this.brandIdValue = brandId || 0
@@ -62,14 +68,33 @@ export default class extends Controller {
     this.hiddenSakeIdTarget.value = ""
     this.closeDropdown()
 
-    if (brandId) {
-      // 銘柄が選択された場合: 商品名入力を有効にする
-      this.inputTarget.disabled = false
-      this.inputTarget.focus()
-    } else {
-      // 銘柄が未選択の場合: 商品名入力を無効にする
-      this.inputTarget.disabled = true
-    }
+    this.inputTarget.disabled = false
+    this.inputTarget.focus()
+  }
+
+  // 銘柄手入力モード → brand_id は 0 のままでも入力欄を有効化
+  onBrandNew() {
+    this.brandIdValue = 0
+
+    // 商品名リセット
+    this.inputTarget.value = ""
+    this.hiddenSakeIdTarget.value = ""
+    this.closeDropdown()
+
+    // 商品名入力活性化
+    this.inputTarget.disabled = false
+    this.inputTarget.focus()
+  }
+
+  // 銘柄クリア → 商品名入力欄を非活性化
+  onBrandCleared() {
+    this.brandIdValue = 0
+
+    this.inputTarget.value = ""
+    this.hiddenSakeIdTarget.value = ""
+    this.closeDropdown()
+
+    this.inputTarget.disabled = true
   }
 
   // 入力欄クリック時に銘柄に紐づく全商品を表示

--- a/app/javascript/controllers/product_name_autocomplete_controller.js
+++ b/app/javascript/controllers/product_name_autocomplete_controller.js
@@ -63,8 +63,7 @@ export default class extends Controller {
     const { brandId } = event.detail
     this.brandIdValue = brandId || 0
 
-    // 銘柄が変わったら商品名リセット
-    this.inputTarget.value = ""
+    // 銘柄が変わったら商品IDリセット
     this.hiddenSakeIdTarget.value = ""
     this.closeDropdown()
 
@@ -76,21 +75,18 @@ export default class extends Controller {
   onBrandNew() {
     this.brandIdValue = 0
 
-    // 商品名リセット
-    this.inputTarget.value = ""
+    // 商品名IDリセット
     this.hiddenSakeIdTarget.value = ""
     this.closeDropdown()
 
     // 商品名入力活性化
     this.inputTarget.disabled = false
-    this.inputTarget.focus()
   }
 
   // 銘柄クリア → 商品名入力欄を非活性化
   onBrandCleared() {
     this.brandIdValue = 0
 
-    this.inputTarget.value = ""
     this.hiddenSakeIdTarget.value = ""
     this.closeDropdown()
 

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -8,18 +8,17 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  brewery_id  :bigint           not null
-#  sakenowa_id :integer          not null
+#  sakenowa_id :integer
 #
 # Indexes
 #
 #  index_brands_on_brewery_id   (brewery_id)
-#  index_brands_on_sakenowa_id  (sakenowa_id) UNIQUE
+#  index_brands_on_sakenowa_id  (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (brewery_id => breweries.id)
 #
-# さけのわAPIから取得する銘柄マスターデータ
 class Brand < ApplicationRecord
   NAME_MAX_LENGTH = 255
 

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -23,6 +23,7 @@ class Brand < ApplicationRecord
   NAME_MAX_LENGTH = 255
 
   validates :name, presence: true, length: { maximum: NAME_MAX_LENGTH }
+  validates :sakenowa_id, uniqueness: true, allow_nil: true
 
   scope :active, -> { where(is_deleted: false) }
 

--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -23,8 +23,22 @@ class Brewery < ApplicationRecord
   NAME_MAX_LENGTH = 255
 
   validates :name, presence: true, length: { maximum: NAME_MAX_LENGTH }
+  validates :sakenowa_id, uniqueness: true, allow_nil: true
 
   scope :active, -> { where(is_deleted: false) }
+
+  # オートコンプリート用の蔵元検索スコープ
+  # 都道府県を eager load し、蔵元名で部分位置検索(上位10件)
+  # @param query [String] 検索文字列
+  # @return [ActiveRecord::Relation<Brewery>]
+  scope :search_by_name, ->(query) {
+    next none if query.blank?
+
+    active
+      .includes(:area)
+      .where("breweries.name LIKE ?", "%#{sanitize_sql_like(query)}%")
+      .limit(10)
+  }
 
   belongs_to :area
   # マスターデータのため削除不可。誤って destroy が呼ばれた場合に例外で知らせる

--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -8,18 +8,17 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  area_id     :bigint           not null
-#  sakenowa_id :integer          not null
+#  sakenowa_id :integer
 #
 # Indexes
 #
 #  index_breweries_on_area_id      (area_id)
-#  index_breweries_on_sakenowa_id  (sakenowa_id) UNIQUE
+#  index_breweries_on_sakenowa_id  (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (area_id => areas.id)
 #
-# さけのわAPIから取得する蔵元マスターデータ
 class Brewery < ApplicationRecord
   NAME_MAX_LENGTH = 255
 

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -23,7 +23,7 @@ class Sake < ApplicationRecord
   validates :product_name, presence: true, length: { maximum: PRODUCT_NAME_MAX_LENGTH }
   validates :product_name, uniqueness: { scope: :brand_id }
 
-  belongs_to :brand, optional: true
+  belongs_to :brand
 
   has_many :sake_logs
 

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -6,7 +6,7 @@
 #  product_name :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  brand_id     :bigint
+#  brand_id     :bigint           not null
 #
 # Indexes
 #

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -80,7 +80,7 @@
          data-area-display-initial-brewery-id-value="<%= sake_log.brewery_id %>"
          data-area-display-initial-area-id-value="<%= sake_log.area_id %>"
          data-area-display-initial-area-name-value="<%= sake_log.area_display_name %>"
-         data-area-display-manual-brewery-mode-value="<%= sake_log.manual_brewery_mode? %>">
+         data-area-display-manual-brewery-mode-value="<%= sake_log.manual_brewery_input_started? %>">
 
       <label class="font-semibold whitespace-nowrap required">都道府県</label>
 

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -79,7 +79,8 @@
          data-area-display-initial-brand-id-value="<%= sake_log.brand_id %>"
          data-area-display-initial-brewery-id-value="<%= sake_log.brewery_id %>"
          data-area-display-initial-area-id-value="<%= sake_log.area_id %>"
-         data-area-display-initial-area-name-value="<%= sake_log.area_display_name %>">
+         data-area-display-initial-area-name-value="<%= sake_log.area_display_name %>"
+         data-area-display-manual-brewery-mode-value="<%= sake_log.manual_brewery_mode? %>">
 
       <label class="font-semibold whitespace-nowrap required">都道府県</label>
 

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -8,27 +8,21 @@
          data-controller="brand-autocomplete"
          data-brand-autocomplete-search-url-value="<%= search_api_brands_path %>"
          data-brand-autocomplete-initial-brand-id-value="<%= sake_log.brand_id %>"
-         data-brand-autocomplete-initial-brand-name-value="<%= sake_log.brand_display_name %>"
-         data-brand-autocomplete-initial-brewery-name-value="<%= sake_log.brewery_display_name %>">
-    
+         data-brand-autocomplete-initial-brand-name-value="<%= sake_log.brand_display_name %>">
+
       <div class="flex gap-2 items-baseline">
         <%= f.label :brand_id, class: "font-semibold whitespace-nowrap required" %>
         <span class="text-xs text-base-content/50">（蔵元のブランド名。例：獺祭、久保田、新政）</span>
       </div>
 
-      <%# hidden フィールド(実際にサブミットされる値) %>
+      <%# hidden フィールド(実際にサブミットされる brand_id) %>
       <%= f.hidden_field :brand_id,
             data: { brand_autocomplete_target: "hiddenBrandId" } %>
-
-      <%# 銘柄手入力モードの hidden フィールド %>
-      <%= f.hidden_field :manual_brand_mode,
-            data: { brand_autocomplete_target: "hiddenManualBrandMode" } %>
-
-      <%# オートコンプリートのテキスト入力欄
-          （通常モード: 銘柄選択用 / 銘柄手入力モード: 銘柄名入力用） %>
+      <%# 銘柄名テキスト入力 %>
       <input type="text"
             class="w-full input input-primary"
             name="sake_log[manual_brand_name]"
+            value="<%= sake_log.brand_display_name %>"
             placeholder="銘柄名を入力してください"
             autocomplete="off"
             data-brand-autocomplete-target="input"
@@ -40,77 +34,70 @@
              data-brand-autocomplete-target="dropdown">
         </div>
       </div>
+    </div>
 
-      <%# 蔵元の自動表示エリア（銘柄選択時に表示） %>
-      <div class="mt-4 <%= sake_log.brand_id.blank? ? 'hidden' : '' %>">
-        <label class="font-semibold whitespace-nowrap">蔵元</label>
-        <input type="text"
-               class="w-full input input-bordered bg-base-200 text-base-content/70"
-               disabled
-               data-brand-autocomplete-target="breweryDisplay">
+    <%# 蔵元(オートコンプリート) %>
+    <%# 銘柄選択時は readonly で自動表示、銘柄手入力モード時は検索/手入力可能になる %>
+    <div class="flex flex-col w-full md:w-8/12"
+         data-controller="brewery-autocomplete"
+         data-brewery-autocomplete-search-url-value="<%= search_api_breweries_path %>"
+         data-brewery-autocomplete-initial-brand-id-value="<%= sake_log.brand_id %>"
+         data-brewery-autocomplete-initial-brewery-id-value="<%= sake_log.brewery_id %>"
+         data-brewery-autocomplete-initial-brewery-name-value="<%= sake_log.brewery_display_name %>">
+
+      <div class="flex gap-2 items-baseline">
+        <label class="font-semibold whitespace-nowrap required">蔵元</label>
+        <span class="text-xs text-base-content/50">（銘柄選択時は自動入力、手入力時は検索または新規登録）</span>
       </div>
 
-      <%# 都道府県の自動表示エリア（通常モード: 銘柄選択時に表示） %>
-      <div class="mt-2 <%= sake_log.brand_id.blank? ? 'hidden' : '' %>">
-        <label class="font-semibold whitespace-nowrap">都道府県</label>
-        <input type="text"
-               class="w-full input input-bordered bg-base-200 text-base-content/70"
-               value="<%= sake_log.area_display_name %>"
-               disabled>
-      </div>
+      <%# hidden フィールド(brewery_id) %>
+      <%= f.hidden_field :brewery_id,
+            data: { brewery_autocomplete_target: "hiddenBreweryId" } %>
+      <%# 蔵元名テキスト入力 %>
+      <input type="text"
+              class="w-full input input-primary"
+              name="sake_log[manual_brewery_name]"
+              value="<%= sake_log.brewery_display_name %>"
+              placeholder="蔵元名を入力してください"
+              autocomplete="off"
+              data-brewery-autocomplete-target="input"
+              data-action="input->brewery-autocomplete#onInput
+              click->brewery-autocomplete#onClick">
 
-      <%# 銘柄手入力モード用のフィールド群 %>
-      <div class="hidden mt-4 flex flex-col gap-4"
-           data-brand-autocomplete-target="manualFields">
-
-        <%# 蔵元オートコンプリート %>
-        <div data-controller="brewery-autocomplete"
-             data-brewery-autocomplete-search-url-value="<%= search_api_breweries_path %>">
-
-          <label class="font-semibold whitespace-nowrap required">蔵元</label>
-          <span class="text-xs text-base-content/50">（蔵元名を入力して選択、または手入力）</span>
-
-          <%= f.hidden_field :brewery_id,
-                data: { brewery_autocomplete_target: "hiddenBreweryId" } %>
-
-          <%# 蔵元名テキスト入力（オートコンプリート + フリー入力兼用） %>
-          <input type="text"
-                 class="w-full input input-primary"
-                 name="sake_log[manual_brewery_name]"
-                 placeholder="蔵元名を入力してください"
-                 autocomplete="off"
-                 data-brewery-autocomplete-target="input"
-                 data-action="input->brewery-autocomplete#onInput
-                 click->brewery-autocomplete#onClick">
-
-          <%# 候補リストのドロップダウン %>
-          <div class="relative">
-            <div class="hidden absolute top-0 right-0 left-0 z-10"
-                 data-brewery-autocomplete-target="dropdown">
-            </div>
-          </div>
-
-          <%# 都道府県 readonly表示（蔵元をオートコンプリートで選択した場合） %>
-          <div class="mt-2">
-            <label class="font-semibold whitespace-nowrap">都道府県</label>
-            <input type="text"
-                   class="hidden w-full input input-bordered bg-base-200 text-base-content/70"
-                   disabled
-                   data-brewery-autocomplete-target="areaDisplay">
-          </div>
-
-          <%# 都道府県 select（蔵元手入力モードで表示） %>
-          <div class="hidden mt-2"
-               data-brewery-autocomplete-target="areaSelectWrapper">
-            <label class="font-semibold whitespace-nowrap required">都道府県</label>
-            <%= f.select :area_id,
-                  sake_log.area_options,
-                  { include_blank: "都道府県を選択してください", prompt: nil },
-                  { class: "w-full select select-primary",
-                    data: { brewery_autocomplete_target: "areaSelect" } } %>
-          </div>
+      <%# 候補リストのドロップダウン %>
+      <div class="relative">
+        <div class="hidden absolute top-0 right-0 left-0 z-10"
+              data-brewery-autocomplete-target="dropdown">
         </div>
       </div>
+    </div>
+
+    <%# 都道府県 %>
+    <%# 通常モードは input(readonly) に都道府県名表示、蔵元手入力時は select に切替 %>
+    <div class="flex flex-col w-full md:w-8/12"
+         data-controller="area-display"
+         data-area-display-initial-brand-id-value="<%= sake_log.brand_id %>"
+         data-area-display-initial-brewery-id-value="<%= sake_log.brewery_id %>"
+         data-area-display-initial-area-id-value="<%= sake_log.area_id %>"
+         data-area-display-initial-area-name-value="<%= sake_log.area_display_name %>">
+
+      <label class="font-semibold whitespace-nowrap required">都道府県</label>
+
+
+      <%# 都道府県 input (readonly 表示用) %>
+      <input type="text"
+             class="w-full input input-bordered bg-base-200 text-base-content/70"
+             value="<%= sake_log.area_display_name %>"
+             disabled
+             data-area-display-target="input">
+
+      <%# 都道府県 select (蔵元手入力モード時のみ活性化) %>
+      <%= f.select :area_id,
+            sake_log.area_options,
+            { include_blank: "都道府県を選択してください", prompt: nil },
+            { class: "hidden w-full select select-primary",
+              disabled: true,
+              data: { area_display_target: "select"} } %>
     </div>
 
     <%# 商品名(オートコンプリート) %>
@@ -134,7 +121,7 @@
       <%= f.text_field :product_name, class: "w-full input input-primary",
             placeholder: "商品名を入力してください",
             autocomplete: "off",
-            disabled: sake_log.brand_id.blank? && !sake_log.persisted?,
+            disabled: !sake_log.brand_committed?,
             data: {
               product_name_autocomplete_target: "input",
               action: "input->product-name-autocomplete#onInput click->product-name-autocomplete#onClick"

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -20,9 +20,15 @@
       <%= f.hidden_field :brand_id,
             data: { brand_autocomplete_target: "hiddenBrandId" } %>
 
-      <%# オートコンプリートのテキスト入力欄（name属性なし、サブミット対象外） %>
+      <%# 銘柄手入力モードの hidden フィールド %>
+      <%= f.hidden_field :manual_brand_mode,
+            data: { brand_autocomplete_target: "hiddenManualBrandMode" } %>
+
+      <%# オートコンプリートのテキスト入力欄
+          （通常モード: 銘柄選択用 / 銘柄手入力モード: 銘柄名入力用） %>
       <input type="text"
             class="w-full input input-primary"
+            name="sake_log[manual_brand_name]"
             placeholder="銘柄名を入力してください"
             autocomplete="off"
             data-brand-autocomplete-target="input"
@@ -36,12 +42,74 @@
       </div>
 
       <%# 蔵元の自動表示エリア（銘柄選択時に表示） %>
-      <div class="mt-4">
-        <label class="font-semibold whitespace-nowrap required">蔵元</label>
+      <div class="mt-4 <%= sake_log.brand_id.blank? ? 'hidden' : '' %>">
+        <label class="font-semibold whitespace-nowrap">蔵元</label>
         <input type="text"
                class="w-full input input-bordered bg-base-200 text-base-content/70"
                disabled
                data-brand-autocomplete-target="breweryDisplay">
+      </div>
+
+      <%# 都道府県の自動表示エリア（通常モード: 銘柄選択時に表示） %>
+      <div class="mt-2 <%= sake_log.brand_id.blank? ? 'hidden' : '' %>">
+        <label class="font-semibold whitespace-nowrap">都道府県</label>
+        <input type="text"
+               class="w-full input input-bordered bg-base-200 text-base-content/70"
+               value="<%= sake_log.area_display_name %>"
+               disabled>
+      </div>
+
+      <%# 銘柄手入力モード用のフィールド群 %>
+      <div class="hidden mt-4 flex flex-col gap-4"
+           data-brand-autocomplete-target="manualFields">
+
+        <%# 蔵元オートコンプリート %>
+        <div data-controller="brewery-autocomplete"
+             data-brewery-autocomplete-search-url-value="<%= search_api_breweries_path %>">
+
+          <label class="font-semibold whitespace-nowrap required">蔵元</label>
+          <span class="text-xs text-base-content/50">（蔵元名を入力して選択、または手入力）</span>
+
+          <%= f.hidden_field :brewery_id,
+                data: { brewery_autocomplete_target: "hiddenBreweryId" } %>
+
+          <%# 蔵元名テキスト入力（オートコンプリート + フリー入力兼用） %>
+          <input type="text"
+                 class="w-full input input-primary"
+                 name="sake_log[manual_brewery_name]"
+                 placeholder="蔵元名を入力してください"
+                 autocomplete="off"
+                 data-brewery-autocomplete-target="input"
+                 data-action="input->brewery-autocomplete#onInput
+                 click->brewery-autocomplete#onClick">
+
+          <%# 候補リストのドロップダウン %>
+          <div class="relative">
+            <div class="hidden absolute top-0 right-0 left-0 z-10"
+                 data-brewery-autocomplete-target="dropdown">
+            </div>
+          </div>
+
+          <%# 都道府県 readonly表示（蔵元をオートコンプリートで選択した場合） %>
+          <div class="mt-2">
+            <label class="font-semibold whitespace-nowrap">都道府県</label>
+            <input type="text"
+                   class="hidden w-full input input-bordered bg-base-200 text-base-content/70"
+                   disabled
+                   data-brewery-autocomplete-target="areaDisplay">
+          </div>
+
+          <%# 都道府県 select（蔵元手入力モードで表示） %>
+          <div class="hidden mt-2"
+               data-brewery-autocomplete-target="areaSelectWrapper">
+            <label class="font-semibold whitespace-nowrap required">都道府県</label>
+            <%= f.select :area_id,
+                  sake_log.area_options,
+                  { include_blank: "都道府県を選択してください", prompt: nil },
+                  { class: "w-full select select-primary",
+                    data: { brewery_autocomplete_target: "areaSelect" } } %>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/app/views/sake_logs/_form.html.erb
+++ b/app/views/sake_logs/_form.html.erb
@@ -11,7 +11,7 @@
          data-brand-autocomplete-initial-brand-name-value="<%= sake_log.brand_display_name %>">
 
       <div class="flex gap-2 items-baseline">
-        <%= f.label :brand_id, class: "font-semibold whitespace-nowrap required" %>
+        <%= f.label :manual_brand_name, class: "font-semibold whitespace-nowrap required" %>
         <span class="text-xs text-base-content/50">（蔵元のブランド名。例：獺祭、久保田、新政）</span>
       </div>
 
@@ -19,14 +19,15 @@
       <%= f.hidden_field :brand_id,
             data: { brand_autocomplete_target: "hiddenBrandId" } %>
       <%# 銘柄名テキスト入力 %>
-      <input type="text"
-            class="w-full input input-primary"
-            name="sake_log[manual_brand_name]"
-            value="<%= sake_log.brand_display_name %>"
-            placeholder="銘柄名を入力してください"
-            autocomplete="off"
-            data-brand-autocomplete-target="input"
-            data-action="input->brand-autocomplete#onInput click->brand-autocomplete#onClick">
+      <%= f.text_field :manual_brand_name,
+            class: "w-full input input-primary",
+            value: sake_log.brand_display_name,
+            placeholder: "銘柄名を入力してください",
+            autocomplete: "off",
+            data: {
+              brand_autocomplete_target: "input",
+              action: "input->brand-autocomplete#onInput click->brand-autocomplete#onClick"
+            } %>
 
       <%# 候補リストのドロップダウン %>
       <div class="relative">
@@ -46,7 +47,7 @@
          data-brewery-autocomplete-initial-brewery-name-value="<%= sake_log.brewery_display_name %>">
 
       <div class="flex gap-2 items-baseline">
-        <label class="font-semibold whitespace-nowrap required">蔵元</label>
+        <%= f.label :manual_brewery_name, class: "font-semibold whitespace-nowrap required" %>
         <span class="text-xs text-base-content/50">（銘柄選択時は自動入力、手入力時は検索または新規登録）</span>
       </div>
 
@@ -54,20 +55,20 @@
       <%= f.hidden_field :brewery_id,
             data: { brewery_autocomplete_target: "hiddenBreweryId" } %>
       <%# 蔵元名テキスト入力 %>
-      <input type="text"
-              class="w-full input input-primary"
-              name="sake_log[manual_brewery_name]"
-              value="<%= sake_log.brewery_display_name %>"
-              placeholder="蔵元名を入力してください"
-              autocomplete="off"
-              data-brewery-autocomplete-target="input"
-              data-action="input->brewery-autocomplete#onInput
-              click->brewery-autocomplete#onClick">
+      <%= f.text_field :manual_brewery_name,
+            class: "w-full input input-primary",
+            value: sake_log.brewery_display_name,
+            placeholder: "蔵元名を入力してください",
+            autocomplete: "off",
+            data: {
+              brewery_autocomplete_target: "input",
+              action: "input->brewery-autocomplete#onInput click->brewery-autocomplete#onClick"
+            } %>
 
       <%# 候補リストのドロップダウン %>
       <div class="relative">
         <div class="hidden absolute top-0 right-0 left-0 z-10"
-              data-brewery-autocomplete-target="dropdown">
+             data-brewery-autocomplete-target="dropdown">
         </div>
       </div>
     </div>
@@ -82,8 +83,7 @@
          data-area-display-initial-area-name-value="<%= sake_log.area_display_name %>"
          data-area-display-manual-brewery-mode-value="<%= sake_log.manual_brewery_input_started? %>">
 
-      <label class="font-semibold whitespace-nowrap required">都道府県</label>
-
+      <%= f.label :area_id, class: "font-semibold whitespace-nowrap required" %>
 
       <%# 都道府県 input (readonly 表示用) %>
       <input type="text"
@@ -98,7 +98,7 @@
             { include_blank: "都道府県を選択してください", prompt: nil },
             { class: "hidden w-full select select-primary",
               disabled: true,
-              data: { area_display_target: "select"} } %>
+              data: { area_display_target: "select" } } %>
     </div>
 
     <%# 商品名(オートコンプリート) %>
@@ -117,7 +117,7 @@
       <%# sake_id hidden フィールド(既存Sake選択時にセット) %>
       <%= f.hidden_field :sake_id,
             data: { product_name_autocomplete_target: "hiddenSakeId" } %>
-      
+
       <%# 商品名入力欄(オートコンプリート + フリー入力兼用) %>
       <%= f.text_field :product_name, class: "w-full input input-primary",
             placeholder: "商品名を入力してください",

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -10,7 +10,12 @@ ja:
         aroma_strength: 香りの濃淡
         taste_strength: 味の濃淡
         review: 感想
+        sake_id: 商品
         product_name: 商品名
         brand_id: 銘柄
-        sake_id: 商品
+        manual_brand_name: 銘柄
+        brewery_id: 蔵元
+        manual_brewery_name: 蔵元
+        area_id: 都道府県
+
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
         get :search # GET /api/sakes/search?brand_id=xxx&q=yyy
       end
     end
+    resources :breweries, only: [] do
+      collection do
+        get :search # GET /api/breweries/search?q=xxx
+      end
+    end
   end
 
   resources :sake_logs, only: %i[index new create edit update destroy]

--- a/db/migrate/20260411074136_change_sakenowa_id_nullable_on_brands_and_breweries.rb
+++ b/db/migrate/20260411074136_change_sakenowa_id_nullable_on_brands_and_breweries.rb
@@ -1,0 +1,13 @@
+class ChangeSakenowaIdNullableOnBrandsAndBreweries < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :brands, :sakenowa_id, true
+
+    change_column_null :breweries, :sakenowa_id, true
+
+    remove_index :brands, :sakenowa_id
+    add_index :brands, :sakenowa_id, unique: true, where: "sakenowa_id IS NOT NULL", name: "index_brands_on_sakenowa_id"
+
+    remove_index :breweries, :sakenowa_id
+    add_index :breweries, :sakenowa_id, unique: true, where: "sakenowa_id IS NOT NULL", name: "index_breweries_on_sakenowa_id"
+  end
+end

--- a/db/migrate/20260411224549_change_brand_id_not_null_on_sakes.rb
+++ b/db/migrate/20260411224549_change_brand_id_not_null_on_sakes.rb
@@ -1,0 +1,15 @@
+class ChangeBrandIdNotNullOnSakes < ActiveRecord::Migration[7.2]
+  def up
+    # 既存データの確認: brand_id が NULL の Sake レコードがあればエラーを発生
+    null_count = Sake.where(brand_id: nil).count
+    if null_count > 0
+      raise "brand_id が NULL の Sake レコードが #{null_count} 件あります。先にデータ移行をしてください。"
+    end
+
+    change_column_null :sakes, :brand_id, false
+  end
+
+  def down
+    change_column_null :sakes, :brand_id, true
+  end
+end

--- a/db/migrate/20260411224549_change_brand_id_not_null_on_sakes.rb
+++ b/db/migrate/20260411224549_change_brand_id_not_null_on_sakes.rb
@@ -1,7 +1,11 @@
 class ChangeBrandIdNotNullOnSakes < ActiveRecord::Migration[7.2]
   def up
     # 既存データの確認: brand_id が NULL の Sake レコードがあればエラーを発生
-    null_count = Sake.where(brand_id: nil).count
+    # ActiveRecordモデルへの依存を避けるため、生SQLで直接sakesテーブルを参照する
+    # (将来 Sakeモデルに default_scope等が追加されてもマイグレーションが影響を受けないようにするため)
+    null_count = connection.select_value(
+      "SELECT COUNT(*) FROM sakes WHERE brand_id IS NULL"
+    ).to_i
     if null_count > 0
       raise "brand_id が NULL の Sake レコードが #{null_count} 件あります。先にデータ移行をしてください。"
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_08_051337) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_11_224549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,25 +23,25 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_08_051337) do
   end
 
   create_table "brands", force: :cascade do |t|
-    t.integer "sakenowa_id", null: false
+    t.integer "sakenowa_id"
     t.string "name", null: false
     t.bigint "brewery_id", null: false
     t.boolean "is_deleted", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["brewery_id"], name: "index_brands_on_brewery_id"
-    t.index ["sakenowa_id"], name: "index_brands_on_sakenowa_id", unique: true
+    t.index ["sakenowa_id"], name: "index_brands_on_sakenowa_id", unique: true, where: "(sakenowa_id IS NOT NULL)"
   end
 
   create_table "breweries", force: :cascade do |t|
-    t.integer "sakenowa_id", null: false
+    t.integer "sakenowa_id"
     t.string "name", null: false
     t.bigint "area_id", null: false
     t.boolean "is_deleted", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["area_id"], name: "index_breweries_on_area_id"
-    t.index ["sakenowa_id"], name: "index_breweries_on_sakenowa_id", unique: true
+    t.index ["sakenowa_id"], name: "index_breweries_on_sakenowa_id", unique: true, where: "(sakenowa_id IS NOT NULL)"
   end
 
   create_table "sake_logs", force: :cascade do |t|
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_08_051337) do
     t.string "product_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "brand_id"
+    t.bigint "brand_id", null: false
     t.index ["brand_id", "product_name"], name: "index_sakes_on_brand_id_and_product_name", unique: true
     t.index ["brand_id"], name: "index_sakes_on_brand_id"
   end


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
さけのわAPIマスターに存在しない銘柄・蔵元を、ユーザーが手入力で登録できるようにする機能を実装。
手入力されたレコードは既存の `brands` / `breweries` テーブルに `sakenowa_id = NULL` で保存され、`Sake → Brand → Brewery → Area` のリレーションチェーンを常に維持する。

# 関連issue
<!-- 閉じたいissue -->
close #222 

# やったこと
<!-- 実施内容を簡潔に -->
## DB スキーマ変更
- `brands.sakenowa_id` / `breweries.sakenowa_id` の NOT NULL 制約を解除し、ユニークインデックスを「`WHERE sakenowa_id IS NOT NULL`」の条件付きユニークに変更
- `sakes.brand_id` を NOT NULL に変更（`Sake → Brand` のリレーションを保証）
- 2 つ目のマイグレーションは生 SQL で `brand_id IS NULL` のレコード数を事前チェックする実装

## モデル
- `Brand` / `Brewery` モデルに `sakenowa_id` のユニークバリデーションを追加（`allow_nil: true`）
- `Brewery` モデルにオートコンプリート用の `search_by_name` スコープを追加
- `Sake` モデルの `belongs_to :brand` から `optional: true` を削除

## SakeLogForm（フォームオブジェクト）
- 手入力用の attribute を追加: `manual_brand_name` / `manual_brewery_name` / `brewery_id` / `area_id`
- バリデーション追加: 手入力モード時に各属性の presence / numericality をチェック
- 保存ロジック: `resolve_brand_id!` で手入力時に `find_or_create_brewery!` → `find_or_create_brand!` の順で重複チェック付きレコード作成
- 表示用ヘルパーメソッドを整理: `brand_display_name` / `brewery_display_name` / `area_display_name` を通常/手入力モードの両対応に
- 状態判定メソッドを追加: `manual_brand_mode?` / `manual_brewery_mode?` / `brand_committed?` / `area_options`

## API
- `Api::BreweriesController#search` を新規作成（`GET /api/breweries/search`）
- `Api::BrandsController` のレスポンスに `brewery_id` / `area_id` を追加し、選択時にフロント側で関連レコードを即座に復元できるように

## SakeLogsController
- `sake_log_form_params` に手入力用パラメータ（`manual_brand_name` / `manual_brewery_name` / `brewery_id` / `area_id`）を追加

## フロントエンド（Stimulus コントローラを SRP で分離）
- 銘柄・蔵元・都道府県・商品名を **独立した 4 つのコントローラ** に分離
  - `brand-autocomplete` / `brewery-autocomplete`（新規）/ `area-display`（新規）/ `product-name-autocomplete`
- コントローラ間は `CustomEvent` で疎結合に連携
  - 銘柄: `brand:selected` / `brand:new` / `brand:cleared`
  - 蔵元: `brewery:selected` / `brewery:new` / `brewery:cleared`
- 「該当する銘柄がない」を **「新しい銘柄として登録」ボタン方式** に変更し、商品名と UX を統一
- 都道府県は `input(readonly)` / `select` を切替表示する `area-display` コントローラを新規作成
- `app/javascript/controllers/index.js` に `area-display` / `brewery-autocomplete` を登録

## フォームビュー
- `_form.html.erb` を 4 コントローラ並列の固定配置に書き換え
- 銘柄・蔵元・都道府県・商品名を常に同じ位置・順序で表示し、状態は活性/非活性で切り替え

# やらないこと
<!-- スコープ外の作業 -->
- 蔵元重複45組の統合対応（Issue #74 の定期更新時に別途実施予定）

# できるようになること(ユーザ目線)
- さけのわAPIマスターに存在しない銘柄を手入力で登録できる
- さけのわAPIマスターに存在しない蔵元を手入力で登録できる（都道府県をセレクトで選択）
- 銘柄/蔵元の手入力モードを「新しい○○として登録」ボタンで開始でき、再入力で通常検索モードに自然に戻れる
- 商品名と銘柄/蔵元で操作感が統一されている

# できなくなること(ユーザ目線)
- なし（既存機能はそのまま動作）

# 影響範囲
## DB
- `brands` / `breweries` テーブル: `sakenowa_id` が nullable に
- `sakes` テーブル: `brand_id` が NOT NULL に変更
- 既存 `Sake` レコードで `brand_id = NULL` のものがある場合、2 つ目のマイグレーションがエラーで停止する（事前移行が必要）

## アプリケーション
- 日本酒記録の新規作成・編集画面（`/sake_logs/new` / `/sake_logs/:id/edit`）の UI が刷新
- `Brand` / `Brewery` の `sakenowa_id` が `nil` のレコードが新たに発生する可能性


# 動作確認とその方法
## マイグレーション
- [x] `docker compose exec web bin/rails db:migrate` が正常完了する
- [x] schema.rb の `sakenowa_id` インデックスが `WHERE (sakenowa_id IS NOT NULL)` の条件付きになっている
- [x] schema.rb の `sakes.brand_id` が `null: false` になっている

## 通常モード（既存機能の回帰）
- [x] 新規作成画面で銘柄をオートコンプリートから選択すると、蔵元名・都道府県が自動表示される
- [x] 編集画面で既存レコードの銘柄・蔵元・都道府県が正しく表示される
- [x] 通常モードで日本酒記録の保存・更新ができる

## 銘柄手入力モード
- [x] 銘柄プルダウンの「新しい銘柄として登録」をクリックすると、蔵元入力欄が活性化する
- [x] 蔵元をオートコンプリートから選択でき、都道府県が自動表示される
- [x] 保存すると `Brand(sakenowa_id: nil)` が新規作成される
- [x] 同名+同蔵元の `Brand` が既にある場合は重複作成されず、既存レコードが再利用される

## 蔵元手入力モード
- [x] 蔵元プルダウンの「新しい蔵元として登録」をクリックすると、都道府県セレクトが活性化する
- [x] 都道府県を選択して保存すると、`Brewery(sakenowa_id: nil)` + `Brand(sakenowa_id: nil)` が新規作成される
- [x] 同名+同エリアの `Brewery` が既にある場合は重複作成されず、既存レコードが再利用される

## UX 改善の確認
- [x] 「新しい銘柄として登録」を選んだ後でも、再度入力すれば検索が再開できる（モードを戻せる）
- [x] 銘柄手入力モードでも商品名入力欄が活性化する
- [x] 銘柄・蔵元・都道府県・商品名の表示順が状態によって入れ替わらない（常に同じ順序）
- [x] 新規作成画面の初期表示で、蔵元・都道府県の入力欄が最初から表示される（非活性状態）

## 静的解析・テスト
- [x] `docker compose exec web bin/rubocop` がパスする
- [x] `docker compose exec web yarn tailwind:check` がパスする

# その他
<!-- 何かあれば -->
## マイグレーション実行の注意
2 つ目のマイグレーション（`ChangeBrandIdNotNullOnSakes`）実行前に、`sakes` テーブルに `brand_id = NULL` のレコードがないことを確認してください。存在する場合は事前にデータ移行が必要です（マイグレーション内でガード処理あり、件数を表示してエラーで停止）。

## アーキテクチャ上のポイント
- **モード判定にフラグを使わない設計**: `manual_mode` のようなフラグ属性を持たず、`brand_id` / `brewery_id` の present/blank だけでサーバー側がモードを判定。状態が一意に決まり、「モードを戻す手段がない」問題が自然に解決する。
- **Stimulus コントローラの単一責任化**: 各コントローラは 1 つの UI 要素のみを管理し、`CustomEvent` で疎結合に連携。将来「銘柄」と「蔵元」を画面上で離して配置するようなレイアウト変更が容易。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 蔵元検索APIを追加
  * 銘柄・蔵元の手動入力フローを実装
  * 都道府県表示／手動選択UIを追加

* **改善**
  * 銘柄検索結果に蔵元・地域の識別子と名称を含めて返すように拡張
  * フォームで蔵元/地域を選択・手入力できるようにし、商品入力の有効/無効挙動を調整
  * エラーマッピングと入力検証を強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiruyan-J/GinLog/pull/240)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->