### PR TITLE
Featrure/81 normalize manual input

### DIFF
--- a/app/forms/sake_log_form.rb
+++ b/app/forms/sake_log_form.rb
@@ -88,7 +88,7 @@ class SakeLogForm
         sake.save!
       rescue ActiveRecord::RecordNotUnique
         sake = Sake.find_by!(
-          product_name: product_name.strip,
+          product_name: product_name,
           brand_id: brand_id
         )
       end
@@ -217,7 +217,7 @@ class SakeLogForm
       Brewery.find(brewery_id)
     else
       Brewery.find_or_create_by!(
-        name: manual_brewery_name.strip,
+        name: manual_brewery_name,
         area_id: area_id
       )
     end
@@ -229,7 +229,7 @@ class SakeLogForm
   # @return [Brand] 既存または新規の Brand レコード
   def find_or_create_brand!(brewery)
     Brand.find_or_create_by!(
-      name: manual_brand_name.strip,
+      name: manual_brand_name,
       brewery_id: brewery.id
     )
   end
@@ -243,7 +243,7 @@ class SakeLogForm
     else
       # 新規のSakeレコードを検索または作成
       Sake.find_or_initialize_by(
-        product_name: product_name.strip,
+        product_name: product_name,
         brand_id: brand_id
       )
     end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -20,7 +20,11 @@
 #  fk_rails_...  (brewery_id => breweries.id)
 #
 class Brand < ApplicationRecord
+  include Normalizable
+
   NAME_MAX_LENGTH = 255
+
+  normalizes_text :name
 
   validates :name, presence: true, length: { maximum: NAME_MAX_LENGTH }
   validates :sakenowa_id, uniqueness: true, allow_nil: true

--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -20,7 +20,11 @@
 #  fk_rails_...  (area_id => areas.id)
 #
 class Brewery < ApplicationRecord
+  include Normalizable
+
   NAME_MAX_LENGTH = 255
+
+  normalizes_text :name
 
   validates :name, presence: true, length: { maximum: NAME_MAX_LENGTH }
   validates :sakenowa_id, uniqueness: true, allow_nil: true

--- a/app/models/concerns/normalizable.rb
+++ b/app/models/concerns/normalizable.rb
@@ -1,0 +1,46 @@
+# 名前・商品名などのテキスト属性を正規化する共通モジュール。
+#
+# 表記揺れ（全角スペース・全角英数字・半角カナ・各種ダッシュ等）を吸収し、
+# find_or_create_by 等の重複判定で同一の値が確実に一致するようにする。
+module Normalizable
+  extend ActiveSupport::Concern
+
+  # 半角ハイフンに統一する対象（長音「ー」U+30FC は意図的に含めない）
+  # - U+2010〜U+2015: ハイフン・各種ダッシュ（HYPHEN 〜 HORIZONTAL BAR）
+  # - U+2212: MINUS SIGN（マイナス記号）
+  # - U+FE58: SMALL EM DASH / U+FE63: SMALL HYPHEN-MINUS
+  HYPHEN_LIKE = /[‐-―−﹘﹣]/
+
+  # テキストを正規化する。
+  #
+  # 処理順:
+  # 1. NFKC 正規化（全角英数字→半角、半角カナ→全角、全角スペース→半角、互換文字の展開）
+  # 2. 長音以外のハイフン・ダッシュ・マイナス類を半角ハイフン "-" に統一
+  # 3. 連続する空白を半角スペース1つに圧縮
+  # 4. 前後の空白を除去
+  #
+  # @param value [String, nil] 正規化対象の文字列
+  # @return [String, nil] 正規化後の文字列（nil はそのまま返す）
+  def self.normalize_text(value)
+    return value if value.nil?
+
+    value.unicode_normalize(:nfkc)
+          .gsub(HYPHEN_LIKE, "-")
+          .gsub(/[[:space:]]+/, " ")
+          .strip
+  end
+
+  class_methods do
+    # 指定した属性にテキスト正規化 (normalize_text) を適用する
+    # normalizes は保存時だけでなく、 find_or_create_by 等の検索時にも適用されるため、
+    # 既存の重複判定ロジック (SakeLogForm) とそのまま整合する。
+    #
+    # @param attribute_names [Array<Symbol>] 正規化対象の属性名
+    # @return [void]
+    def normalizes_text(*attribute_names)
+      attribute_names.each do |attribute_name|
+        normalizes attribute_name, with: ->(value) { Normalizable.normalize_text(value) }
+      end
+    end
+  end
+end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -18,7 +18,11 @@
 #  fk_rails_...  (brand_id => brands.id)
 #
 class Sake < ApplicationRecord
+  include Normalizable
+
   PRODUCT_NAME_MAX_LENGTH = 255
+
+  normalizes_text :product_name
 
   validates :product_name, presence: true, length: { maximum: PRODUCT_NAME_MAX_LENGTH }
   validates :product_name, uniqueness: { scope: :brand_id }

--- a/app/models/sake_log.rb
+++ b/app/models/sake_log.rb
@@ -33,6 +33,8 @@ class SakeLog < ApplicationRecord
   AROMA_STRENGTH_DEFAULT = 5.0
   REVIEW_MAX_LENGTH = 65_535
 
+  normalizes :review, with: ->(value) { value.strip }
+
   belongs_to :user
   belongs_to :sake
 


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->

日本酒記録の手入力項目(銘柄・蔵元・商品名)について、入力値の表記揺れをサーバー側で正規化し、重複レコード発生を防止する。
あわせて感想（review）の前後空白も除去する。

# 関連issue
<!-- 閉じたいissue -->
closes #81 

# やったこと
<!-- 実施内容を簡潔に -->
- Normalizableモジュールを作成
  - NFKC + ハイフン/ダッシュ統一 + 連続空白圧縮 + trim
- `Brand` / `Brewery` / `Sake` に `Normalizable` を include し `normalizes_text` を追加
- `SakeLog` に review（感想）の前後 strip を追加（NFKC は適用しない）
- `SakeLogForm` の `find_or_create_by` / `find_by` に渡す名前の `.strip` を削除


# やらないこと
<!-- スコープ外の作業 -->
- 既存データの一括正規化
- フロント側（入力中）の見た目調整 — サーバー側のみで対応

# できるようになること(ユーザ目線)
- 銘柄・蔵元・商品名を全角/半角混在で入力しても、自動的に正規化されて保存される。
- 同じ銘柄を表記揺れありで入力しても、既存レコードに紐付けられ重複登録されない。
- 感想の前後に余分な空白・改行が混ざっても、自動的に取り除いて保存される。
  （本文中の改行・字下げ・段落分けは維持）

# できなくなること(ユーザ目線)
- 全角英数字・半角カナで入力しても、表記が自動的に標準形（半角英数字・全角カナ）に変換される。
  （例: `Ｎｏ．６` → `No.6` / `ｱｵｲ` → `アオイ`）
- 銘柄・蔵元・商品名の前後・連続空白、各種ダッシュ（`―` `−` 等）は半角・標準形に揃えられる。
  ※ 長音記号「ー」は変換対象外で保持される。

# 影響範囲
- 銘柄・蔵元・商品・感想（`Brand` / `Brewery` / `Sake` / `SakeLog` ）の 保存処理
- 上記モデルに対する **`find_by` / `find_or_create_by` / `find_or_initialize_by`**  の検索条件にも正規化が適用される
- 既存データ（マスター取り込み済みの Brand / Brewery 等）は遡及されない

# 動作確認とその方法
- [x] Rails コンソールで `Normalizable.normalize_text` が想定通り動くこと
    ```ruby
    Normalizable.normalize_text("獺祭　磨き二割三分")  # => "獺祭 磨き二割三分"
    Normalizable.normalize_text("Ｎｏ．６")            # => "No.6"
    Normalizable.normalize_text("シリーズ ― 限定")     # => "シリーズ - 限定"
    ```
- [x] 同じ銘柄を表記揺れありで2回登録しても、Brand / Sake が重複しないこと （find_or_create_by の検索キーにも normalizes が効くことの確認）
- [x] 感想(review)のtrimが効くこと
    ```ruby
    log = SakeLog.new(review: "  美味しかった！\n香りも華やか  \n")
    log.valid?
    log.review  # => "美味しかった！\n香りも華やか"
    ```

# その他
<!-- 何かあれば -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 商品名、蔵元名、銘柄名、レビューテキストの入力値に対する自動正規化を実装しました。余分な空白の圧縮、ハイフン表記の統一、前後の空白自動削除により、データの一貫性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiruyan-J/GinLog/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->