### PR TITLE
chore: brakemanを8.0.5に更新しRails EOL警告をignore登録

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     byebug (13.0.0)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,24 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 254,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails 7.2 の EOL(2026-08-09) は Rails 8 へのアップグレードで対応する（別Issueで計画）。それまで本警告を許容する。"
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
Brakeman を 8.0.5 に更新し、CI（scan_ruby）の失敗を解消する。
あわせて 8.0.5 が新たに報告する Rails 7.2 EOL 警告を ignore 登録する。

# 関連issue
<!-- 閉じたいissue -->
なし（CI 修正のため）

# やったこと
<!-- 実施内容を簡潔に -->
- brakeman を 8.0.4 → 8.0.5 に更新（Gemfile.lock）
- `config/brakeman.ignore` を追加し、Rails 7.2 EOL 警告（EOLRails / fingerprint `98b26f60…`）を note 付きで ignore 登録

# やらないこと
<!-- スコープ外の作業 -->
- Rails 7.2 → 8 のアップグレード本体（別 Issue で対応予定）
- 他の Dependabot 依存更新

# できるようになること(ユーザ目線)
- （エンドユーザー向けの変更なし。開発者向け）
- CI の scan_ruby が通り、各 PR をマージできる状態に戻る

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- `Gemfile.lock`（brakeman のみ）と `config/brakeman.ignore` の追加のみ。アプリの挙動に影響なし

# 動作確認とその方法
- [ ] `docker compose exec web bin/brakeman --no-pager` が exit 0（Security Warnings: 0 / Ignored Warnings: 1）
- [ ] CI の scan_ruby が pass

# その他
<!-- 何かあれば -->
- Rails デフォルト binstub の `--ensure-latest` により、8.0.4 は「最新でない」で exit 5、8.0.5 では Rails EOL 警告で exit 3 となるため、bump と ignore をセットで対応
- Rails 7.2 EOL（2026-08-09）対応は別 Issue で起票予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
