### PR TITLE
test: SakeLogForm の重複レコード再利用スペックを追加

### DIFF
--- a/spec/forms/sake_log_form_spec.rb
+++ b/spec/forms/sake_log_form_spec.rb
@@ -206,6 +206,49 @@ RSpec.describe SakeLogForm, type: :model do
       end
     end
 
+    # find_or_create_brewery! / find_or_create_brand! が
+    # 「既存レコードがあれば再利用し、二重登録しない」ことを独立して検証する。
+    context "重複レコードの再利用（既存があれば新規作成しない）" do
+      let(:area) { create(:area) }
+
+      it "蔵元手入力: 同名・同都道府県の Brewery が既存なら再利用する" do
+        existing_brewery = create(:brewery, name: "赤武酒造", area: area)
+
+        form = SakeLogForm.new(
+          {
+            product_name: "純米酒",
+            manual_brand_name: "新規銘柄",  # 銘柄は新規（Brand は増える）
+            manual_brewery_name: "赤武酒造",
+            area_id: area.id,
+            rating: 3, aroma_strength: 5.0, taste_strength: 5.0
+          },
+          user: user
+        )
+
+        expect { form.save }.to change(Brewery, :count).by(0)
+        expect(form.sake_log.sake.brand.brewery).to eq existing_brewery
+      end
+
+      it "銘柄手入力: 同名・同蔵元の Brand が既存なら再利用する" do
+        existing_brewery = create(:brewery, name: "赤武酒造", area: area)
+        existing_brand = create(:brand, name: "赤武", brewery: existing_brewery)
+
+        form = SakeLogForm.new(
+          {
+            product_name: "純米酒",
+            manual_brand_name: "赤武",
+            manual_brewery_name: "赤武酒造",
+            area_id: area.id,
+            rating: 3, aroma_strength: 5.0, taste_strength: 5.0
+          },
+          user: user
+        )
+
+        expect { form.save }.to change(Brand, :count).by(0)
+        expect(form.sake_log.sake.brand).to eq existing_brand
+      end
+    end
+
     context "編集（既存 sake_log を渡す）" do
       it "rating を更新できる" do
         sake_log = create(:sake_log, rating: 2)


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
SakeLogForm の「重複レコードの再利用（既存があれば新規作成しない）」を検証するスペックの追加。

# 関連issue
<!-- 閉じたいissue -->
なし（Issue 不要の軽微なテスト追補のため）

# やったこと
<!-- 実施内容を簡潔に -->
- `spec/forms/sake_log_form_spec.rb` に `context "重複レコードの再利用（既存があれば新規作成しない）"` を追加
  - ① 蔵元手入力: 同名・同都道府県の Brewery が既存なら再利用する（`find_or_create_brewery!`）
  - ② 銘柄手入力: 同名・同蔵元の Brand が既存なら再利用する（`find_or_create_brand!`）
- 既存の「正規化による重複防止」テストへの相乗りを解消し、表記揺れなしの完全一致での再利用を独立して検証

# やらないこと
<!-- スコープ外の作業 -->
- なし

# できるようになること(ユーザ目線)
- なし

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- テストコードのみでアプリ本体・DB・CI 設定への変更なし

# 動作確認とその方法
- [x] rspecテストを全て通過する。

# その他
<!-- 何かあれば -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - 手入力モードで、同名かつ同一条件の既存の蔵元・銘柄がある場合に、新規レコードを作成せず既存レコードを再利用する動作の検証を追加しました。
  - 保存後に正しい既存レコードへ関連付けられることも確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->