### PR TITLE
chore: SimpleCov の add_filter を skip に置換（deprecation 対応）

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,8 +3,8 @@
 # SimpleCov はアプリのコードが読み込まれる前に起動する必要がある（計測漏れ防止）
 require "simplecov"
 SimpleCov.start "rails" do
-  add_filter "/spec/"
-  add_filter "/config/"
+  skip "/spec/"
+  skip "/config/"
   # enable_coverage :branch  # 分岐網羅
 end
 


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
SimpleCov を 0.22.0 → 1.0.0 にアップデート（#268）した影響で、
RSpec 実行時に `SimpleCov.add_filter` の deprecation 警告が出るようになったため、
推奨される `SimpleCov.skip` へ置き換え。

## 背景
`bundle exec rspec` 実行時に以下の警告が出力されていました。

```
[DEPRECATION] SimpleCov.add_filter is deprecated. Replace with SimpleCov.skip
(same arguments, same behavior). Example: SimpleCov.skip "/spec/".
```

# 関連issue
<!-- 閉じたいissue -->
close #[issue番号]

# やったこと
<!-- 実施内容を簡潔に -->
- `spec/rails_helper.rb` の `add_filter` を `skip` に置換（2箇所）

# やらないこと
<!-- スコープ外の作業 -->
- なし

# できるようになること(ユーザ目線)
- なし

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- なし

# 動作確認とその方法
- [x]  bundle exec rspec で deprecation 警告が出ないこと
- [x] カバレッジ計測の除外対象（/spec/・/config/）が従来通り機能すること

# その他
<!-- 何かあれば -->