### PR TITLE
test: 各モデル単体スペックの実装（Normalizable 含む）

### DIFF
--- a/spec/models/area_spec.rb
+++ b/spec/models/area_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Area, type: :model do
+  describe "バリデーション" do
+    subject { build(:area) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(Area::NAME_MAX_LENGTH) }
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to have_many(:breweries).dependent(:restrict_with_exception) }
+  end
+end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Brand, type: :model do
+  describe "バリデーション" do
+    subject { build(:brand) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(Brand::NAME_MAX_LENGTH) }
+
+    describe "sakenowa_id の一意性(allow_nil)" do
+      # validate_uniqueness_of は「既存レコード」が必要なため create で永続化する
+      subject { create(:brand, sakenowa_id: 1) }
+
+      it { is_expected.to validate_uniqueness_of(:sakenowa_id).allow_nil }
+    end
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:brewery) }
+    it { is_expected.to have_many(:sakes) }
+  end
+
+  describe "正規化(normalizes_text :name)" do
+    it "全角英数字・全角スペースを正規化して代入する" do
+      full_width_space = "　" # 全角スペース
+      brand = build(:brand, name: "#{full_width_space}ＡＫＡＢＵ#{full_width_space}純米酒#{full_width_space}")
+
+      expect(brand.name).to eq "AKABU 純米酒"
+    end
+  end
+
+  describe ".active スコープ" do
+    it "is_deleted: false のレコードだけを返す" do
+      active_brand = create(:brand, is_deleted: false)
+      deleted_brand = create(:brand, is_deleted: true)
+
+      expect(Brand.active).to include(active_brand)
+      expect(Brand.active).not_to include(deleted_brand)
+    end
+  end
+
+  describe ".search_by_name スコープ" do
+    it "名前の部分一致で active なレコードを返す" do
+      matched = create(:brand, name: "赤武")
+      unmatched = create(:brand, name: "獺祭")
+
+      result = Brand.search_by_name("赤")
+
+      expect(result).to include(matched)
+      expect(result).not_to include(unmatched)
+    end
+
+    it "is_deleted のレコードは除外する" do
+      deleted = create(:brand, name: "赤武", is_deleted: true)
+
+      expect(Brand.search_by_name("赤")).not_to include(deleted)
+    end
+
+    it "空文字なら none を返す" do
+      create(:brand, name: "赤武")
+
+      expect(Brand.search_by_name("")).to be_empty
+    end
+
+    it "最大10件までに制限する" do
+      11.times { |i| create(:brand, name: "検索銘柄#{i}") }
+
+      expect(Brand.search_by_name("検索銘柄").size).to eq 10
+    end
+  end
+end

--- a/spec/models/brewery_spec.rb
+++ b/spec/models/brewery_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Brewery, type: :model do
+  describe "バリデーション" do
+    subject { build(:brewery) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(Brewery::NAME_MAX_LENGTH) }
+
+    describe "sakenowa_id の一意性(allow_nil)" do
+      # validate_uniqueness_of は「既存レコード」が必要なため create で永続化する
+      subject { create(:brewery, sakenowa_id: 1) }
+
+      it { is_expected.to validate_uniqueness_of(:sakenowa_id).allow_nil }
+    end
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:area) }
+    it { is_expected.to have_many(:brands).dependent(:restrict_with_exception) }
+  end
+
+  describe "正規化(normalizes_text :name)" do
+    it "全角スペース・連続空白を正規化して代入する" do
+      full_width_space = "　" # 全角スペース
+      brewery = build(:brewery, name: "#{full_width_space}新政#{full_width_space}#{full_width_space}酒造#{full_width_space}")
+
+      expect(brewery.name).to eq "新政 酒造"
+    end
+  end
+
+  describe ".active スコープ" do
+    it "is_deleted: false のレコードだけを返す" do
+      active_brewery = create(:brewery, is_deleted: false)
+      deleted_brewery = create(:brewery, is_deleted: true)
+
+      expect(Brewery.active).to include(active_brewery)
+      expect(Brewery.active).not_to include(deleted_brewery)
+    end
+  end
+
+  describe ".search_by_name スコープ" do
+    it "名前の部分一致で active なレコードを返す" do
+      matched = create(:brewery, name: "新政酒造")
+      unmatched = create(:brewery, name: "獺祭酒造")
+
+      result = Brewery.search_by_name("新政")
+
+      expect(result).to include(matched)
+      expect(result).not_to include(unmatched)
+    end
+
+    it "is_deleted のレコードは除外する" do
+      deleted = create(:brewery, name: "新政酒造", is_deleted: true)
+
+      expect(Brewery.search_by_name("新政")).not_to include(deleted)
+    end
+
+    it "空文字なら none を返す" do
+      create(:brewery, name: "新政酒造")
+
+      expect(Brewery.search_by_name("")).to be_empty
+    end
+
+    it "最大10件までに制限する" do
+      11.times { |i| create(:brewery, name: "検索酒造#{i}") }
+
+      expect(Brewery.search_by_name("検索酒造").size).to eq 10
+    end
+  end
+end

--- a/spec/models/concerns/normalizable_spec.rb
+++ b/spec/models/concerns/normalizable_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Normalizable do
+  describe ".normalize_text" do
+    context "NFKC 正規化" do
+      it "全角英数字を半角に変換する" do
+        expect(Normalizable.normalize_text "ＡＢＣ１２３").to eq "ABC123"
+      end
+
+      it "全角スペースを半角スペースに変換する" do
+        full_width_space = "　" # 全角スペース
+        expect(Normalizable.normalize_text "新政#{full_width_space}酒造").to eq "新政 酒造"
+      end
+
+      it "半角カナを全角カナに変換する" do
+        expect(Normalizable.normalize_text("ﾀｶﾁﾖ")).to eq "タカチヨ"
+      end
+    end
+
+    context "ハイフン・ダッシュ・マイナス類の統一" do
+      it "各種ダッシュ(U+2010〜U+2015)を半角ハイフンに統一する" do
+        hyphen  = "‐" # ‐ HYPHEN
+        em_dash = "—" # — EM DASH
+        bar     = "―" # ― HORIZONTAL BAR
+
+        expect(Normalizable.normalize_text("A#{hyphen}B")).to eq "A-B"
+        expect(Normalizable.normalize_text("A#{em_dash}B")).to eq "A-B"
+        expect(Normalizable.normalize_text("A#{bar}B")).to eq "A-B"
+      end
+
+      it "マイナス記号(U+2212)を半角ハイフンに統一する" do
+        minus = "−" # − MINUS SIGN
+
+        expect(Normalizable.normalize_text("A#{minus}B")).to eq "A-B"
+      end
+    end
+
+    context "長音「ー」(U+30FC) の保護" do
+      it "長音はハイフンに変換されない" do
+        long_vowel = "ー" # ー 長音記号(U+30FC)
+
+        expect(Normalizable.normalize_text("ビール")).to eq "ビール"
+        expect(Normalizable.normalize_text("ビール")).to include(long_vowel)
+      end
+    end
+
+    context "空白の圧縮・strip" do
+      it "連続する空白を1つに圧縮し、前後の空白を除去する" do
+        expect(Normalizable.normalize_text("  獺祭   純米   ")).to eq "獺祭 純米"
+      end
+    end
+
+    context "nil" do
+      it "nil はそのまま nil を返す" do
+        expect(Normalizable.normalize_text(nil)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/concerns/normalizable_spec.rb
+++ b/spec/models/concerns/normalizable_spec.rb
@@ -19,19 +19,25 @@ RSpec.describe Normalizable do
 
     context "ハイフン・ダッシュ・マイナス類の統一" do
       it "各種ダッシュ(U+2010〜U+2015)を半角ハイフンに統一する" do
-        hyphen  = "‐" # ‐ HYPHEN
-        em_dash = "—" # — EM DASH
-        bar     = "―" # ― HORIZONTAL BAR
+        (0x2010..0x2015).each do |code_point|
+          dash = code_point.chr(Encoding::UTF_8)
 
-        expect(Normalizable.normalize_text("A#{hyphen}B")).to eq "A-B"
-        expect(Normalizable.normalize_text("A#{em_dash}B")).to eq "A-B"
-        expect(Normalizable.normalize_text("A#{bar}B")).to eq "A-B"
+          expect(Normalizable.normalize_text("A#{dash}B")).to eq "A-B"
+        end
       end
 
       it "マイナス記号(U+2212)を半角ハイフンに統一する" do
-        minus = "−" # − MINUS SIGN
+        minus = 0x2212.chr(Encoding::UTF_8) # − MINUS SIGN
 
         expect(Normalizable.normalize_text("A#{minus}B")).to eq "A-B"
+      end
+
+      it "小書きダッシュ(U+FE58 / U+FE63)を半角ハイフンに統一する" do
+        small_em_dash      = 0xFE58.chr(Encoding::UTF_8) # ﹘ SMALL EM DASH
+        small_hyphen_minus = 0xFE63.chr(Encoding::UTF_8) # ﹣ SMALL HYPHEN-MINUS
+
+        expect(Normalizable.normalize_text("A#{small_em_dash}B")).to eq "A-B"
+        expect(Normalizable.normalize_text("A#{small_hyphen_minus}B")).to eq "A-B"
       end
     end
 

--- a/spec/models/sake_log_spec.rb
+++ b/spec/models/sake_log_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SakeLog, type: :model do
+  describe "バリデーション" do
+    subject { build(:sake_log) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:rating) }
+    it { is_expected.to validate_presence_of(:taste_strength) }
+    it { is_expected.to validate_presence_of(:aroma_strength) }
+
+    it "rating は下限・上限の境界内かつ整数のみ有効" do
+      is_expected.to validate_numericality_of(:rating)
+        .only_integer
+        .is_greater_than_or_equal_to(SakeLog::RATING_MIN)
+        .is_less_than_or_equal_to(SakeLog::RATING_MAX)
+    end
+
+    it "taste_strength は下限・上限の境界内のみ有効" do
+      is_expected.to validate_numericality_of(:taste_strength)
+        .is_greater_than_or_equal_to(SakeLog::TASTE_STRENGTH_MIN)
+        .is_less_than_or_equal_to(SakeLog::TASTE_STRENGTH_MAX)
+    end
+
+    it "aroma_strength は下限・上限の境界内のみ有効" do
+      is_expected.to validate_numericality_of(:aroma_strength)
+        .is_greater_than_or_equal_to(SakeLog::AROMA_STRENGTH_MIN)
+        .is_less_than_or_equal_to(SakeLog::AROMA_STRENGTH_MAX)
+    end
+
+    describe "review の文字数" do
+      it { is_expected.to validate_length_of(:review).is_at_most(SakeLog::REVIEW_MAX_LENGTH) }
+
+      it "空でも有効(任意項目)" do
+        expect(build(:sake_log, review: "")).to be_valid
+      end
+    end
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:sake) }
+  end
+
+  describe "reviewの正規化" do
+    it "前後の空白を除去して代入する" do
+      sake_log = build(:sake_log, review: "  余韻が長い  ")
+
+      expect(sake_log.review).to eq "余韻が長い"
+    end
+  end
+end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Sake, type: :model do
+  describe "バリデーション" do
+    subject { build(:sake) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:product_name) }
+    it { is_expected.to validate_length_of(:product_name).is_at_most(Sake::PRODUCT_NAME_MAX_LENGTH) }
+
+    describe "product_name の一意性(brand_id スコープ)" do
+      # validate_uniqueness_of は「既存レコード」が必要なため create で永続化する
+      subject { create(:sake, product_name: "AKABU 純米酒") } # テストするproduct_nameには英字を含めること
+
+      it { is_expected.to validate_uniqueness_of(:product_name).scoped_to(:brand_id) }
+    end
+
+    it "別の銘柄なら同じ商品名でも登録できる" do
+      create(:sake, product_name: "純米大吟醸", brand: create(:brand))
+      other = build(:sake, product_name: "純米大吟醸", brand: create(:brand))
+
+      expect(other).to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:brand) }
+    it { is_expected.to have_many(:sake_logs) }
+  end
+
+  describe "正規化(normalizes_text :product_name)" do
+    it "全角スペース・連続空白を正規化して代入する" do
+      full_width_space = "　" # 全角スペース
+      sake = build(:sake, product_name: "#{full_width_space}純米#{full_width_space}#{full_width_space}大吟醸#{full_width_space}")
+
+      expect(sake.product_name).to eq "純米 大吟醸"
+    end
+  end
+
+  describe ".search_by_product_name スコープ" do
+    let(:brand) { create(:brand) }
+
+    it "指定した銘柄内で商品名の部分一致を返す" do
+      matched = create(:sake, brand: brand, product_name: "純米大吟醸")
+      unmatched = create(:sake, brand: brand, product_name: "本醸造")
+
+      result = Sake.search_by_product_name(brand.id, "大吟醸")
+
+      expect(result).to include(matched)
+      expect(result).not_to include(unmatched)
+    end
+
+    it "別の銘柄の商品は含まない" do
+      other_brand = create(:brand)
+      other_sake = create(:sake, brand: other_brand, product_name: "純米大吟醸")
+
+      result = Sake.search_by_product_name(brand.id, "大吟醸")
+
+      expect(result).not_to include(other_sake)
+    end
+
+    it "空文字なら none を返す" do
+      create(:sake, brand: brand, product_name: "純米大吟醸")
+
+      expect(Sake.search_by_product_name(brand.id, "")).to be_empty
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe "バリデーション" do
+    subject { build(:user) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to have_many(:sake_logs).dependent(:destroy) }
+  end
+
+  describe "#own?" do
+    let(:user) { create(:user) }
+
+    it "自分の投稿なら true を返す" do
+      sake_log = create(:sake_log, user: user)
+      expect(user.own?(sake_log)).to be true
+    end
+
+    it "他人の投稿なら false を返す" do
+      other_sake_log = create(:sake_log)
+      expect(user.own?(other_sake_log)).to be false
+    end
+
+    it "引数が nil でも例外にならず false を返す" do
+      expect(user.own?(nil)).to be false
+    end
+  end
+end


### PR DESCRIPTION
# 概要
各モデル（User / Area / Brewery / Brand / Sake / SakeLog）と共通モジュール `Normalizable` の単体スペックを実装しました。バリデーション・アソシエーション・scope・テキスト正規化を網羅しています。

# 関連issue
close #267

# やったこと
- `Normalizable.normalize_text` の単体スペック（NFKC 正規化 / ハイフン類の統一 / 長音「ー」の保護 / 連続空白の圧縮・strip / nil）
- 各モデルの単体スペックを追加
  - **User**: name presence / `#own?` / sake_logs の dependent: :destroy
  - **Area**: name presence・length / breweries の dependent: :restrict_with_exception
  - **Brewery**: presence・length / sakenowa_id uniqueness(allow_nil) / normalizes_text / `active` / `search_by_name`
  - **Brand**: 同上 + brewery / sakes のアソシエーション
  - **Sake**: product_name presence・length / uniqueness(scope: brand_id) / normalizes_text / `search_by_product_name`
  - **SakeLog**: rating / taste_strength / aroma_strength の numericality / review length / normalizes(strip)
- shoulda-matchers を活用（`validate_presence_of` / `validate_uniqueness_of` / `validate_numericality_of` / `have_many(...).dependent(...)` 等）
- 境界値はモデル定数（`SakeLog::RATING_MIN` 等）を参照し、モデル定義とテストを一元化

# やらないこと
- `SakenowaApiClient` のスペック（Issue #267 のスコープ外）
- システムスペック（MVP 後に対応）
- アプリ本体コードの変更

# できるようになること(ユーザ目線)
- なし（テスト追加のみのため、ユーザー向けの機能変更はありません）

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- CI（GitHub Actions）の実行時間が微増

# 動作確認とその方法
- [x] `docker compose exec web bundle exec rspec spec/models`
- [x] `docker compose exec web bundle exec rspec`
- [x] `docker compose exec web bin/rubocop`

# その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 各モデルのバリデーション、関連付け、検索機能を検証するテストを追加しました。
  * 酒蔵名・銘柄名・レビューなどの入力値正規化に関するテストを追加しました。
  * 有効データの絞り込み、重複防止、検索結果数の制限を検証します。
  * ユーザーの投稿所有権判定や関連データ削除の動作を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->