### PR TITLE
Feature/250 brewery master dedup

### DIFF
--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -2,22 +2,25 @@
 #
 # Table name: breweries
 #
-#  id          :bigint           not null, primary key
-#  is_deleted  :boolean          default(FALSE), not null
-#  name        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  area_id     :bigint           not null
-#  sakenowa_id :integer
+#  id             :bigint           not null, primary key
+#  is_deleted     :boolean          default(FALSE), not null
+#  name           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  area_id        :bigint           not null
+#  merged_into_id :bigint
+#  sakenowa_id    :integer
 #
 # Indexes
 #
-#  index_breweries_on_area_id      (area_id)
-#  index_breweries_on_sakenowa_id  (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
+#  index_breweries_on_area_id         (area_id)
+#  index_breweries_on_merged_into_id  (merged_into_id)
+#  index_breweries_on_sakenowa_id     (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (area_id => areas.id)
+#  fk_rails_...  (merged_into_id => breweries.id)
 #
 class Brewery < ApplicationRecord
   include Normalizable

--- a/app/models/brewery.rb
+++ b/app/models/brewery.rb
@@ -34,6 +34,9 @@ class Brewery < ApplicationRecord
 
   scope :active, -> { where(is_deleted: false) }
 
+  # import_brands の統合先解決マップ作成で使用
+  scope :merged, -> { where.not(merged_into_id: nil) }
+
   # オートコンプリート用の蔵元検索スコープ
   # 都道府県を eager load し、蔵元名で部分位置検索(上位10件)
   # @param query [String] 検索文字列
@@ -48,6 +51,12 @@ class Brewery < ApplicationRecord
   }
 
   belongs_to :area
+  # 統合先の蔵元（自分が重複データだった場合のみ設定される）
+  belongs_to :merged_into, class_name: "Brewery", optional: true
+
+  # 自分を統合先としている重複蔵元の一覧
+  has_many :merged_from, class_name: "Brewery", foreign_key: :merged_into_id,
+                         inverse_of: :merged_into, dependent: :restrict_with_exception
   # マスターデータのため削除不可。誤って destroy が呼ばれた場合に例外で知らせる
   has_many :brands, dependent: :restrict_with_exception
 end

--- a/app/services/sakenowa_api_client.rb
+++ b/app/services/sakenowa_api_client.rb
@@ -101,6 +101,8 @@ class SakenowaApiClient
 
     # nameが空の酒蔵の sakenowa_id を収集(銘柄の論理削除判定用)
     deleted_brewery_sakenowa_ids = []
+    # 重複統合した蔵元の件数(ログ出力用)
+    merged_brewery_count = 0
 
     Brewery.transaction do
       breweries_data.each do |brewery_data|
@@ -118,7 +120,16 @@ class SakenowaApiClient
           brewery.name = brewery_data["name"]
           # APIのareaIdを変換マップでRailsのarea_idに変換
           brewery.area_id = area_id_map[brewery_data["areaId"]]
-          brewery.is_deleted = false
+
+          if brewery.new_record? && (merge_target = find_merge_target(brewery))
+            # 新規レコードが既存の active な蔵元と name + area_id で重複
+            # → 論理削除 + 統合先を記録して保存(sakenowa_id の対応関係は保持する)
+            brewery.is_deleted = true
+            brewery.merged_into_id = merge_target.id
+            merged_brewery_count += 1
+          elsif brewery.merged_into_id.nil?
+            brewery.is_deleted = false
+          end
         end
 
         brewery.save!
@@ -130,7 +141,7 @@ class SakenowaApiClient
         .update_all(is_deleted: true)
     end
 
-    Rails.logger.info("さけのわAPI: 蔵元 #{breweries_data.size} 件インポートしました（name空による論理削除: #{deleted_brewery_sakenowa_ids.size} 件）")
+    Rails.logger.info("さけのわAPI: 蔵元 #{breweries_data.size} 件インポートしました（name空による論理削除: #{deleted_brewery_sakenowa_ids.size} 件、重複統合: #{merged_brewery_count} 件）")
     deleted_brewery_sakenowa_ids
   end
 
@@ -150,8 +161,12 @@ class SakenowaApiClient
     end
 
     api_brand_sakenowa_ids = brands_data.map { |b| b["id"] }
+
     # さけのわAPIの蔵元ID → Railsの蔵元IDの変換マップの事前作成(N+1対策)
+    # 統合済み蔵元(merged_into_id あり)は統合先の brewery_id へ解決してからマップ化
+    merged_into_id_map = Brewery.merged.pluck(:id, :merged_into_id).to_h
     brewery_id_map = Brewery.pluck(:sakenowa_id, :id).to_h
+      .transform_values { |brewery_id| merged_into_id_map[brewery_id] || brewery_id }
 
     deleted_brand_count = 0
 
@@ -184,5 +199,17 @@ class SakenowaApiClient
     end
 
     Rails.logger.info("さけのわAPI: 銘柄 #{brands_data.size} 件インポートしました（論理削除: #{deleted_brand_count} 件）")
+  end
+
+  # 新規蔵元と name + area_id が一致する既存のactiveな蔵元を検索する
+  # 統合先は常に古いID(最小ID)に統一する
+  # ※ name は normalizes_text により代入時に正規化済み
+  # @param brewery [Brewery] 保存前の新規 Brewery
+  # @return [Brewery, nil] 統合先の蔵元(重複がなければ nil)
+  def find_merge_target(brewery)
+    Brewery.active
+      .where(name: brewery.name, area_id: brewery.area_id)
+      .order(:id)
+      .first
   end
 end

--- a/db/migrate/20260720072448_add_merge_into_to_breweries.rb
+++ b/db/migrate/20260720072448_add_merge_into_to_breweries.rb
@@ -1,0 +1,5 @@
+class AddMergeIntoToBreweries < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :breweries, :merged_into, foreign_key: { to_table: :breweries }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_11_224549) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_20_072448) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "areas", force: :cascade do |t|
     t.integer "sakenowa_id", null: false
@@ -40,7 +40,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_11_224549) do
     t.boolean "is_deleted", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "merged_into_id"
     t.index ["area_id"], name: "index_breweries_on_area_id"
+    t.index ["merged_into_id"], name: "index_breweries_on_merged_into_id"
     t.index ["sakenowa_id"], name: "index_breweries_on_sakenowa_id", unique: true, where: "(sakenowa_id IS NOT NULL)"
   end
 
@@ -81,6 +83,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_11_224549) do
 
   add_foreign_key "brands", "breweries"
   add_foreign_key "breweries", "areas"
+  add_foreign_key "breweries", "breweries", column: "merged_into_id"
   add_foreign_key "sake_logs", "sakes"
   add_foreign_key "sake_logs", "users"
   add_foreign_key "sakes", "brands"

--- a/spec/factories/breweries.rb
+++ b/spec/factories/breweries.rb
@@ -2,22 +2,25 @@
 #
 # Table name: breweries
 #
-#  id          :bigint           not null, primary key
-#  is_deleted  :boolean          default(FALSE), not null
-#  name        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  area_id     :bigint           not null
-#  sakenowa_id :integer
+#  id             :bigint           not null, primary key
+#  is_deleted     :boolean          default(FALSE), not null
+#  name           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  area_id        :bigint           not null
+#  merged_into_id :bigint
+#  sakenowa_id    :integer
 #
 # Indexes
 #
-#  index_breweries_on_area_id      (area_id)
-#  index_breweries_on_sakenowa_id  (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
+#  index_breweries_on_area_id         (area_id)
+#  index_breweries_on_merged_into_id  (merged_into_id)
+#  index_breweries_on_sakenowa_id     (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (area_id => areas.id)
+#  fk_rails_...  (merged_into_id => breweries.id)
 #
 FactoryBot.define do
   factory :brewery do

--- a/spec/models/brewery_spec.rb
+++ b/spec/models/brewery_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Brewery, type: :model do
   describe "アソシエーション" do
     it { is_expected.to belong_to(:area) }
     it { is_expected.to have_many(:brands).dependent(:restrict_with_exception) }
+    it { is_expected.to belong_to(:merged_into).class_name("Brewery").optional }
+    it {
+      is_expected.to have_many(:merged_from).class_name("Brewery")
+        .with_foreign_key(:merged_into_id).inverse_of(:merged_into)
+        .dependent(:restrict_with_exception)
+    }
   end
 
   describe "正規化(normalizes_text :name)" do
@@ -61,6 +67,16 @@ RSpec.describe Brewery, type: :model do
 
       expect(Brewery.active).to include(active_brewery)
       expect(Brewery.active).not_to include(deleted_brewery)
+    end
+  end
+
+  describe ".merged スコープ" do
+    it "merged_into_id があるレコードだけを返す" do
+      merge_target = create(:brewery)
+      merged = create(:brewery, is_deleted: true, merged_into: merge_target)
+
+      expect(Brewery.merged).to include(merged)
+      expect(Brewery.merged).not_to include(merge_target)
     end
   end
 

--- a/spec/models/brewery_spec.rb
+++ b/spec/models/brewery_spec.rb
@@ -4,22 +4,25 @@ require 'rails_helper'
 #
 # Table name: breweries
 #
-#  id          :bigint           not null, primary key
-#  is_deleted  :boolean          default(FALSE), not null
-#  name        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  area_id     :bigint           not null
-#  sakenowa_id :integer
+#  id             :bigint           not null, primary key
+#  is_deleted     :boolean          default(FALSE), not null
+#  name           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  area_id        :bigint           not null
+#  merged_into_id :bigint
+#  sakenowa_id    :integer
 #
 # Indexes
 #
-#  index_breweries_on_area_id      (area_id)
-#  index_breweries_on_sakenowa_id  (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
+#  index_breweries_on_area_id         (area_id)
+#  index_breweries_on_merged_into_id  (merged_into_id)
+#  index_breweries_on_sakenowa_id     (sakenowa_id) UNIQUE WHERE (sakenowa_id IS NOT NULL)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (area_id => areas.id)
+#  fk_rails_...  (merged_into_id => breweries.id)
 #
 RSpec.describe Brewery, type: :model do
   describe "バリデーション" do

--- a/spec/services/sakenowa_api_client_spec.rb
+++ b/spec/services/sakenowa_api_client_spec.rb
@@ -148,6 +148,98 @@ RSpec.describe SakenowaApiClient do
       end
     end
 
+    context "蔵元の重複統合(merged_into_id)" do
+      let!(:area) { create(:area, sakenowa_id: 1) }
+
+      it "新規レコードが既存 active な蔵元と name + area_id で重複 → 論理削除 + merged_into_id を記録する" do
+        existing = create(:brewery, sakenowa_id: 305, area: area, name: "朝日酒造", is_deleted: false)
+        stub_sakenowa(:breweries, body: { "breweries" => [
+          { "id" => 305, "name" => "朝日酒造", "areaId" => 1 },
+          { "id" => 909, "name" => "朝日酒造", "areaId" => 1 }
+        ] })
+
+        client.send(:import_breweries)
+
+        duplicated = Brewery.find_by(sakenowa_id: 909)
+        expect(duplicated.is_deleted).to be true
+        expect(duplicated.merged_into).to eq existing
+        # 統合先は active のまま維持される
+        expect(existing.reload.is_deleted).to be false
+      end
+
+      it "name, area_id の両方が一致しない蔵元は統合しない" do
+        create(:area, sakenowa_id: 2)
+        create(:brewery, sakenowa_id: 305, area: area, name: "朝日酒造", is_deleted: false)
+        stub_sakenowa(:breweries, body: { "breweries" => [
+          { "id" => 305, "name" => "朝日酒造", "areaId" => 1 },
+          { "id" => 808, "name" => "朝日酒造", "areaId" => 2 },
+          { "id" => 909, "name" => "新政酒造", "areaId" => 1 }
+        ] })
+
+        client.send(:import_breweries)
+
+        aggregate_failures do
+          # name は同じだが別エリア
+          same_name_other_area = Brewery.find_by(sakenowa_id: 808)
+          expect(same_name_other_area.is_deleted).to be false
+          expect(same_name_other_area.merged_into_id).to be_nil
+
+          # 同じエリアだが name が違う
+          same_area_other_name = Brewery.find_by(sakenowa_id: 909)
+          expect(same_area_other_name.is_deleted).to be false
+          expect(same_area_other_name.merged_into_id).to be_nil
+        end
+      end
+
+      it "統合済み既存レコード（merged_into_id あり）は、APIに name ありで再登場しても is_deleted を false に巻き戻さない" do
+        merge_target = create(:brewery, sakenowa_id: 305, area: area, name: "朝日酒造", is_deleted: false)
+        merged = create(:brewery, sakenowa_id: 909, area: area, name: "朝日酒造",
+                        is_deleted: true, merged_into: merge_target)
+        stub_sakenowa(:breweries, body: { "breweries" => [
+          { "id" => 305, "name" => "朝日酒造", "areaId" => 1 },
+          { "id" => 909, "name" => "朝日酒造", "areaId" => 1 }
+        ] })
+
+        client.send(:import_breweries)
+
+        expect(merged.reload.is_deleted).to be true
+        expect(merged.merged_into).to eq merge_target
+      end
+
+      it "論理削除済みの同名蔵元は統合先にならない" do
+        create(:brewery, sakenowa_id: 305, area: area, name: "朝日酒造", is_deleted: true)
+        # 305 は API 未掲載なので論理削除のまま。909 だけが新規で入る
+        stub_sakenowa(:breweries, body: { "breweries" => [
+          { "id" => 909, "name" => "朝日酒造", "areaId" => 1 }
+        ] })
+
+        client.send(:import_breweries)
+
+        new_brewery = Brewery.find_by(sakenowa_id: 909)
+        expect(new_brewery.merged_into_id).to be_nil
+        expect(new_brewery.is_deleted).to be false
+      end
+
+      it "3件以上の重複はすべて最小IDの蔵元へ統合される" do
+        stub_sakenowa(:breweries, body: { "breweries" => [
+          { "id" => 305, "name" => "朝日酒造", "areaId" => 1 },
+          { "id" => 909, "name" => "朝日酒造", "areaId" => 1 },
+          { "id" => 918, "name" => "朝日酒造", "areaId" => 1 }
+        ] })
+
+        client.send(:import_breweries)
+
+        # 最初に保存された 305 が統合先(最小ID)として active のまま残る
+        merge_target = Brewery.find_by(sakenowa_id: 305)
+        expect(merge_target.is_deleted).to be false
+        expect(merge_target.merged_into_id).to be_nil
+
+        merged = Brewery.where(sakenowa_id: [ 909, 918 ])
+        expect(merged.pluck(:is_deleted)).to all(be true)
+        expect(merged.pluck(:merged_into_id)).to all(eq merge_target.id)
+      end
+    end
+
     it "API 未掲載の既存 active 蔵元が is_deleted: true になる" do
       area = create(:area, sakenowa_id: 1)
       kept = create(:brewery, sakenowa_id: 101, area: area, is_deleted: false)
@@ -208,6 +300,30 @@ RSpec.describe SakenowaApiClient do
         brand = Brand.find_by(sakenowa_id: 1001)
         expect(brand.name).to eq "元の銘柄名"
         expect(brand.is_deleted).to be true
+      end
+    end
+
+    context "統合済み蔵元の銘柄" do
+      it "merged_into_id がある蔵元の銘柄は統合先の brewery_id で保存される" do
+        create(:brewery, sakenowa_id: 909, merged_into: brewery1, is_deleted: true)
+        stub_sakenowa(:brands, body: { "brands" => [ { "id" => 1001, "name" => "得月", "breweryId" => 909 } ] })
+
+        client.send(:import_brands, [])
+
+        brand = Brand.find_by(sakenowa_id: 1001)
+        expect(brand.brewery_id).to eq brewery1.id
+        expect(brand.is_deleted).to be false
+      end
+
+      it "既存銘柄が統合前の蔵元に紐づいている場合、再importで統合先へ付け替わる" do
+        merged_brewery = create(:brewery, sakenowa_id: 909, merged_into: brewery1, is_deleted: true)
+        brand = create(:brand, sakenowa_id: 1001, brewery: merged_brewery, name: "得月", is_deleted: false)
+        stub_sakenowa(:brands, body: { "brands" => [ { "id" => 1001, "name" => "得月", "breweryId" => 909 } ] })
+
+        client.send(:import_brands, [])
+
+        expect(brand.reload.brewery_id).to eq brewery1.id
+        expect(brand.is_deleted).to be false
       end
     end
 
@@ -272,6 +388,32 @@ RSpec.describe SakenowaApiClient do
       # 削除された蔵元(101)の銘柄は、name があっても連鎖で論理削除される（配線が効いるかの確認）
       expect(Brand.find_by(sakenowa_id: 1001).is_deleted).to be true
       expect(Brand.find_by(sakenowa_id: 1002).is_deleted).to be false
+    end
+
+    it "重複蔵元を含む import を2回実行しても結果が同じ（冪等性）" do
+      stub_sakenowa(:areas, body: { "areas" => [ { "id" => 1, "name" => "新潟" } ] })
+      stub_sakenowa(:breweries, body: { "breweries" => [
+        { "id" => 305, "name" => "朝日酒造", "areaId" => 1 },
+        { "id" => 909, "name" => "朝日酒造", "areaId" => 1 }
+      ] })
+      stub_sakenowa(:brands, body: { "brands" => [
+        { "id" => 1001, "name" => "久保田", "breweryId" => 305 },
+        { "id" => 1002, "name" => "得月", "breweryId" => 909 }
+      ] })
+
+      client.import_all
+
+      # 2回目の実行で蔵元・銘柄の状態が一切変わらないこと
+      expect { client.import_all }.not_to change {
+        [
+          Brewery.order(:id).pluck(:sakenowa_id, :is_deleted, :merged_into_id),
+          Brand.order(:id).pluck(:sakenowa_id, :brewery_id, :is_deleted)
+        ]
+      }
+
+      # 全銘柄が統合先(古いID側)へ集約されていること
+      merge_target = Brewery.find_by(sakenowa_id: 305)
+      expect(merge_target.brands.active.pluck(:name)).to contain_exactly("久保田", "得月")
     end
 
     it "途中 breweries で空データを受け取ると raise し、それ以降を実行しない" do


### PR DESCRIPTION
# 概要
さけのわAPIで同一蔵元に複数の `sakenowa_id` が振られているため、`breweries` に `name` + `area_id` が同一の重複レコードが存在していた（2026-07-22 時点のAPIデータで43組）。

`breweries` に `merged_into_id`（self参照FK）を追加し、**import 処理の中で重複を自動検出・統合**する方式を実装した。統合済みレコードが active に巻き戻らないガードにより、定期 import を何度実行しても統合状態が維持される（冪等性）。

# 関連issue
close #250

# やったこと
- `breweries.merged_into_id` カラムを追加（self参照FK・null許可・インデックスあり）
- `Brewery` に self参照アソシエーション（`merged_into` / `merged_from`）と `merged` スコープを追加
- `SakenowaApiClient#import_breweries` に重複検出ロジックを追加
  - 新規レコードのみ `name` + `area_id` で既存 active な蔵元を検索し、見つかれば `is_deleted: true` + `merged_into_id` を記録
  - 統合済みレコードが API に name ありで再登場しても `is_deleted` を巻き戻さないガードを追加
- `SakenowaApiClient#import_brands` の `brewery_id_map` 作成時に、統合済み蔵元を統合先IDへ解決するよう変更
- 上記のモデルスペック・サービススペックを追加（重複統合5件・統合先解決2件・冪等性1件）

# やらないこと
- **既存重複を一括マージする rake タスクの実装**
  - リリース前で開発・本番とも一般公開していないため、**DBリセット + 再import** で解消する方針に変更
  - 空のDBに import すると各ペアの1件目が統合先となり、2件目が自動統合されるため、専用タスクは不要と判断
  - APIデータの重複43組はすべて2件ペア（3件以上のグループは0組）で、統合先の連鎖も発生しない
- `breweries` の `name` + `area_id` へのユニーク制約追加
  - APIの正規データを弾くリスクがあるため、統合判定はアプリ層で行う
- 重複レコードの物理削除
  - `sakenowa_id` との対応関係を保持するため、論理削除 + `merged_into_id` で管理する
- 改名によって既存レコード同士が同名化するケースの検出（後述の「その他」参照）

# できるようになること(ユーザ目線)
- 蔵元検索で同じ蔵元が重複して表示されなくなる
- 統合された蔵元の銘柄も、統合先の蔵元から引けるようになる
  - 例：朝日酒造で「久保田」「朝日山」に加え、従来は別レコードにあった「得月」「勝保」も選択可能になった（10銘柄）
- 定期 import を実行しても、統合済みの状態が巻き戻らない

# できなくなること(ユーザ目線)
- 統合された側の蔵元レコードは論理削除されるため、蔵元検索の候補に表示されなくなる
  - ただし銘柄はすべて統合先に集約されるため、ユーザーが選べる選択肢は減らない

# 影響範囲
- `breweries` テーブル（カラム追加）
- `SakenowaApiClient` の `import_breweries` / `import_brands`
- 蔵元オートコンプリート（`Brewery.search_by_name` は `active` スコープ経由のため、統合済みは自動的に除外される）
- 銘柄オートコンプリート（`Brand.search_by_name` は brewery を eager load しているため、統合先の蔵元名が表示される）
- **既存の `SakeLog` / `Sake` のロジックは変更していない**

# 動作確認とその方法
- [x] Rubocop（74ファイル）: no offenses
- [x] Brakeman: No warnings found
- [x] RSpec: 127 examples, 0 failures
- [x] 開発環境で `db:schema:load` → `sakenowa:import` を実行し、以下を確認
  - 蔵元 1,749件 / 銘柄 3,253件がインポートされる
  - `Brewery.merged.count` → **43件**（統合が記録されている）
  - active な重複（`GROUP BY name, area_id HAVING COUNT(*) > 1`）→ **0組**
- [x] 統合先経由で銘柄が引けることを確認
  - 朝日酒造の銘柄に「得月」「勝保」が含まれる（統合元にあった銘柄が集約されている）
- [x] `sakenowa:import` を再実行しても、統合状態・重複数が変化しないこと（冪等性）
- [x] ブラウザから新規に日本酒記録を登録できること
- [x] **マージ後、本番環境（Neon）でDBリセット + 再importを実施**

# その他
### 本番環境の対応（マージ後に実施）
本番DBにも重複が存在するため、マージ後に本番環境（Neon）でDBリセット + 再importを実施する。

### 既知の制約
重複検出は `brewery.new_record?` が true のときのみ動作するため、**改名によって既存レコード同士が同名化するケースは検出されない**。

将来「改名で既存active同士が同名化し、かつ両方がAPIに残る」ケースが出た場合は、`find_merge_target` に**自己除外（`where.not(id: brewery.id)`）を追加した上で** `new_record?` 条件を緩和する必要がある。自己除外がないと `merged_into_id` が自己参照になり、active な蔵元が論理削除される。

### 設計メモ
- 統合先は `find_merge_target` の `order(:id).first` で決まる。空のDBへの import ではAPIのレスポンス順に採番されるため、各ペアの1件目が統合先になる
- `import_brands` が `merged_into_id` を解決するため、どちらが統合先になっても全銘柄は統合先に集約される


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 重複する蔵元情報を自動的に統合し、統合先へ関連付けるようになりました。
  * 統合元の蔵元に紐づく銘柄も、統合先の蔵元へ正しく引き継がれます。
  * 蔵元データの再インポート時に、既存情報が不必要に変化しないようになりました。
  * 論理削除済みの蔵元や条件の異なる蔵元は、誤って統合されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->