### PR TITLE
feat: マイログ一覧に味×香りの4象限マップを追加

### DIFF
--- a/app/helpers/taste_aroma_map_helper.rb
+++ b/app/helpers/taste_aroma_map_helper.rb
@@ -1,0 +1,72 @@
+# 味 × 香りの4象限マップ（shared/_taste_aroma_map）の表示ロジックをまとめたヘルパー。
+# 「どの象限に属するか」の判定と「象限セルの CSS クラス」を提供する。
+#
+# SakeLog（taste_strength / aroma_strength）と
+# Sake（average_taste_strength / average_aroma_strength）で同じ判定を使用
+module TasteAromaMapHelper
+  # 象限判定の境界値。この値以上なら右側（味が濃い）・上側（香りが華やか）に分類する
+  QUADRANT_BOUNDARY = 5.0
+
+  # 各象限に適用する Tailwind CSS クラス
+  # active（活性象限）: 濃い背景 + 実線枠 / inactive（非活性象限）: 薄い背景 + 破線枠
+  QUADRANT_STYLES = {
+    # 左上: 香り華やか × 味スッキリ
+    aroma_high_taste_light: { active: "bg-green-200 border-green-400 border-solid", inactive: "bg-green-50 border-green-200 border-dashed" },
+    # 右上: 香り華やか × 味濃い
+    aroma_high_taste_strong: { active: "bg-red-200 border-red-400 border-solid", inactive: "bg-red-50 border-red-200 border-dashed" },
+    # 左下: 香り穏やか × 味スッキリ
+    aroma_low_taste_light: { active: "bg-sky-300 border-sky-400 border-solid", inactive: "bg-sky-50 border-sky-200 border-dashed" },
+    # 右下: 香り穏やか × 味濃い
+    aroma_low_taste_strong: { active: "bg-amber-200 border-amber-400 border-solid", inactive: "bg-amber-50 border-amber-200 border-dashed" }
+  }.freeze
+
+  # 4象限マップの外枠サイズ(幅)のプリセット
+  QUADRANT_MAP_SIZES = {
+    sm: "w-16 md:w-24",  # 一覧カード（マイログ / タイムライン）
+    md: "w-48 md:w-56", # 中間サイズ
+    lg: "w-64 md:w-80"  # 詳細画面など広い画面
+  }.freeze
+
+  # 味・香りの値から4象限マップのどの象限に属するかを判定する
+  # 味（横軸）: 5.0 未満は light（スッキリ）/ 5.0 以上は strong（濃い）
+  # 香り（縦軸）: 5.0 未満は low（穏やか）/ 5.0 以上は high（華やか）
+  #
+  # @param taste_strength [Float] 味の濃淡（SakeLog#taste_strength / Sake#average_taste_strength）
+  # @param aroma_strength [Float] 香りの濃淡（SakeLog#aroma_strength / Sake#average_aroma_strength）
+  # @return [Symbol] 象限のキー
+  def taste_aroma_quadrant(taste_strength, aroma_strength)
+    aroma_level = aroma_strength >= QUADRANT_BOUNDARY ? "high" : "low"
+    taste_level = taste_strength >= QUADRANT_BOUNDARY ? "strong" : "light"
+    :"aroma_#{aroma_level}_taste_#{taste_level}"
+  end
+
+  # 4象限マップの1象限分の Tailwind CSS クラスを返す
+  # 描画対象の象限が活性象限と一致すれば active、それ以外は inactive のクラスを返す
+  #
+  # @param quadrant [Symbol] 描画対象の象限キー
+  # @param active_quadrant [Symbol, nil] 活性化する象限のキー (nil なら全象限が非活性)
+  # @return [String] Tailwind CSS クラス文字列
+  def quadrant_cell_class(quadrant, active_quadrant)
+    state = quadrant == active_quadrant ? :active : :inactive
+    QUADRANT_STYLES.fetch(quadrant).fetch(state)
+  end
+
+  # 4象限マップの軸ラベルに付ける表示クラスを返す
+  # :responsive はスマホ（md 未満）で非表示・md 以上で表示（一覧のコンパクト表示）
+  # :always は常に表示（詳細画面などスペースが十分な画面用・デフォルト）
+  #
+  # @param display_mode [Symbol] ラベルの表示方式（:always = 常に表示 / :responsive = スマホで非表示）
+  # @return [String] Tailwind CSS クラス文字列（:always のときは空文字）
+  def quadrant_label_class(display_mode)
+    display_mode == :responsive ? "hidden md:block" : ""
+  end
+
+  # 4象限マップの外枠に付ける幅クラスを返す
+  # 呼び出し側は用途名(:sm / :md / :lg)でサイズ指定可能
+  #
+  # @param size [Symbol] サイズ名（:sm = 一覧カード / :md = 中 / :lg = 詳細画面）
+  # @return [String] Tailwind CSS の幅クラス
+  def quadrant_map_size_class(size)
+    QUADRANT_MAP_SIZES.fetch(size)
+  end
+end

--- a/app/views/sake_logs/_sake_log.html.erb
+++ b/app/views/sake_logs/_sake_log.html.erb
@@ -27,10 +27,10 @@
           <span class="inline-block w-3 h-3 md:w-5 md:h-5 mask mask-star-2 <%= star_rating_class(rate, sake_log.rating) %> " aria-hidden="true"></span>
         <% end %>
       </div>
-      <%# 香りの濃淡 %>
-      <p><%= "#{SakeLog.human_attribute_name(:aroma_strength)}：#{sake_log.aroma_strength}" %></p>
-      <%# 味の濃淡 %>
-      <p><%= "#{SakeLog.human_attribute_name(:taste_strength)}：#{sake_log.taste_strength}" %></p>
+      <%# 味 × 香りの4象限マップ %>
+      <div class="my-2">
+        <%= render "shared/taste_aroma_map", taste: sake_log.taste_strength, aroma: sake_log.aroma_strength, variant: :quadrant, size: :sm, labels: :responsive %>
+      </div>
       <%# 感想 %>
       <%= simple_format(h(sake_log.review), class: "py-2") %>
     </section>

--- a/app/views/shared/_taste_aroma_map.html.erb
+++ b/app/views/shared/_taste_aroma_map.html.erb
@@ -44,7 +44,7 @@
       <polyline points="286,94 294,100 286,106" />
       <polyline points="14,94 6,100 14,106" />
       <polyline points="144,14 150,6 156,14" />
-      <polyline points="144,186 150,194 15e6,186" />
+      <polyline points="144,186 150,194 156,186" />
     </svg>
   </div>
 

--- a/app/views/shared/_taste_aroma_map.html.erb
+++ b/app/views/shared/_taste_aroma_map.html.erb
@@ -1,0 +1,56 @@
+<%# 味 × 香りの4象限マップ
+  locals:
+    taste:   味の濃淡の値（SakeLog#taste_strength / Sake#average_taste_strength）
+    aroma:   香りの濃淡の値（SakeLog#aroma_strength / Sake#average_aroma_strength）
+    variant: 表示方式（:quadrant = 該当する1象限だけをハイライト）
+    size:    外枠サイズ（省略時 :sm / :md / :lg。呼び出し側は用途名で指定）
+    labels:  軸ラベルの表示方式（省略時 :always = 常に表示 / :responsive = スマホで非表示）
+  サイズは呼び出し側のラッパー要素の幅で制御する（内部は幅 100% で描画）
+%>
+
+<% active_quadrant = taste_aroma_quadrant(taste, aroma) if variant == :quadrant %>
+
+<%# 外枠サイズ（size 省略時は :sm）・軸ラベルの表示クラス（labels 省略時は :always） %>
+<% size_class = quadrant_map_size_class(local_assigns.fetch(:size, :sm)) %>
+<% label_class = quadrant_label_class(local_assigns.fetch(:labels, :always)) %>
+
+<div class="<%= size_class %> grid grid-cols-[auto_1fr_auto] grid-rows-[auto_1fr_auto] items-center justify-items-center gap-1 text-[10px] leading-none text-neutral-500">
+  <%# 上の軸ラベル %>
+  <p class="col-start-2 row-start-1 <%= label_class %>">香りが華やか</p>
+
+  <%# 左の軸ラベル(縦書き) %>
+  <p class="col-start-1 row-start-2 [writing-mode:vertical-rl] <%= label_class %>">味がスッキリ</p>
+
+  <%# 2×2 の象限グリッド（並び順は 左上 → 右上 → 左下 → 右下） %>
+  <div class="grid relative grid-cols-2 col-start-2 grid-rows-2 row-start-2 gap-1 w-full aspect-[3/2]">
+    <%# 左上: 香り華やか × 味スッキリ（緑） %>
+    <div class="rounded-md border <%= quadrant_cell_class(:aroma_high_taste_light, active_quadrant) %>"></div>
+
+    <%# 右上: 香り華やか × 味濃い（ピンク） %>
+    <div class="rounded-md border <%= quadrant_cell_class(:aroma_high_taste_strong, active_quadrant) %>"></div>
+
+    <%# 左下: 香り穏やか × 味スッキリ（水色） %>
+    <div class="rounded-md border <%= quadrant_cell_class(:aroma_low_taste_light, active_quadrant) %>"></div>
+
+    <%# 右下: 香り穏やか × 味濃い（クリーム） %>
+    <div class="rounded-md border <%= quadrant_cell_class(:aroma_low_taste_strong, active_quadrant) %>"></div>
+
+    <%# 座標軸（縦横線 + 4方向の矢印）。マップ中央に重ねる。%>
+    <svg class="absolute inset-0 w-full h-full pointer-events-none text-neutral-400" viewBox="0 0 300 200" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+      <%# 横軸（味）・縦軸（香り） %>
+      <line x1="6" y1="100" x2="294" y2="100" />
+      <line x1="150" y1="6" x2="150" y2="194" />
+      <%# 矢印（右・左・上・下） %>
+      <polyline points="286,94 294,100 286,106" />
+      <polyline points="14,94 6,100 14,106" />
+      <polyline points="144,14 150,6 156,14" />
+      <polyline points="144,186 150,194 15e6,186" />
+    </svg>
+  </div>
+
+  <%# 右の軸ラベル(縦書き) %>
+  <p class="col-start-3 row-start-2 [writing-mode:vertical-rl] <%= label_class %>">味が濃い</p>
+
+  <%# 下の軸ラベル %>
+  <p class="col-start-2 row-start-3 <%= label_class %>">香りが穏やか</p>
+</div>


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
マイログ一覧の各記録カードに「味 × 香りの4象限マップ（象限ハイライト方式）」を表示する。
各記録の `taste_strength`（味の濃淡）・`aroma_strength`（香りの濃淡）から、その記録がどの象限に属するかを判定し、該当する1象限を色濃く・実線枠でハイライトする。
今後のタイムライン（#80）・記録詳細画面（#82・#27）でも再利用できるよう、共通ヘルパー + 共通パーシャルとして実装。

# 関連issue
<!-- 閉じたいissue -->
close #79 

# やったこと
<!-- 実施内容を簡潔に -->
- 共通ヘルパー `TasteAromaMapHelper` を新規作成（味・香りの値から象限を判定 / 象限セル・軸ラベル・サイズの CSS クラスを組み立て）
- 共通パーシャル `shared/_taste_aroma_map` を新規作成（`variant: :quadrant` のみ実装）
- 象限判定を**値ベース**にし、SakeLog / 将来の Sake（集計）双方で再利用可能に
- 座標軸
- 軸ラベルは `labels: :responsive` でスマホ時に非表示（一覧のコンパクト表示）
- サイズは `size:` プリセット（`:sm`/`:md`/`:lg`）で指定（幅クラスの直書きを回避）
- マイログ一覧カードの「香りの濃淡 / 味の濃淡」テキスト表示をマップに置き換え

# やらないこと
<!-- スコープ外の作業 -->
- 点プロット表示（`variant: :plot`）… 記録詳細画面の実装とあわせて #27 で対応
- タイムライン一覧への組み込み … #80 で対応
- 記録詳細画面の新設 … #82 で対応
- カードのレイアウト調整（マップを好み度・日付の右隣へ配置 / レビュー非表示）… ラベル写真機能とセットで別対応

# できるようになること(ユーザ目線)
- マイログ一覧で、各記録の味・香りの傾向を4象限マップで直感的に把握できる
- スマホでは軸ラベルが自動的に隠れ、コンパクトに一覧を閲覧できる

# できなくなること(ユーザ目線)
- マイログ一覧での「香りの濃淡：5.0 / 味の濃淡：5.0」という数値テキスト表示（マップに置き換え）

# 影響範囲
- マイログ一覧画面（`app/views/sake_logs/_sake_log.html.erb`）の表示
- 新規追加のため既存機能への副作用なし（DB 変更・マイグレーションなし。既存カラムを読むのみ）

# 動作確認とその方法
- [ ] マイログ一覧で各カードに4象限マップが表示される
- [ ] 記録の値に応じて該当する1象限だけがハイライト（濃い背景 + 実線枠）される
- [ ] 境界値どおりに分類される（味・香りとも `5.0 以上`は右/上、`5.0 未満`は左/下）
- [ ] スマホ幅では軸ラベルが非表示、`md` 以上で表示される
- [ ] Rubocop / Tailwind ソートチェックが通る（`bin/rubocop` / `yarn tailwind:check`）

# その他
<!-- 何かあれば -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 味と香りの強さを4象限で可視化するマップを追加しました。
  * サイズやラベル表示を切り替えられるマップ表示に対応しました。
  * 日本酒ログの指標表示を、数値テキストから味×香りマップへ変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->