### PR TITLE
feat: タイムライン一覧に味×香りの4象限マップを追加

### DIFF
--- a/app/views/timeline/_sake_log.html.erb
+++ b/app/views/timeline/_sake_log.html.erb
@@ -32,10 +32,11 @@
           <span class="inline-block w-3 h-3 md:w-5 md:h-5 mask mask-star-2 <%= star_rating_class(rate, sake_log.rating) %> " aria-hidden="true"></span>
         <% end %>
       </div>
-      <%# 香りの濃淡 %>
-      <p><%= "#{SakeLog.human_attribute_name(:aroma_strength)}：#{sake_log.aroma_strength}" %></p>
-      <%# 味の濃淡 %>
-      <p><%= "#{SakeLog.human_attribute_name(:taste_strength)}：#{sake_log.taste_strength}" %></p>
+      <%# 味 × 香りの4象限マップ %>
+      <div class="my-2">
+        <%= render "shared/taste_aroma_map", taste: sake_log.taste_strength, aroma: sake_log.aroma_strength, variant: :quadrant, size: :sm, labels: :responsive %>
+      </div>
+
       <%# 感想 %>
       <%= simple_format(h(sake_log.review), class: "py-2") %>
     </section>


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
タイムライン一覧（`app/views/timeline/_sake_log.html.erb`）の各記録カードに、味 × 香りの4象限マップを表示する。

# 関連issue
<!-- 閉じたいissue -->
close #80

# やったこと
<!-- 実施内容を簡潔に -->
- タイムライン一覧の記録カードに4象限マップ（`variant: :quadrant, size: :sm, labels: :responsive`）を組み込んだ
- 既存のテキスト表示「香りの濃淡：x」「味の濃淡：x」を4象限マップに置き換えた

# やらないこと
<!-- スコープ外の作業 -->
- 共通パーシャル・ヘルパーの新規作成（#79 で実装済みのものを再利用）
- タイムラインカード全体のレイアウト変更（マップの配置移動など）→ ラベル写真機能とセットで別Issue

# できるようになること(ユーザ目線)
- タイムラインの各投稿で、記録の味・香りがどの象限（スッキリ×穏やか／濃い×華やかなど）に属するか一目で分かるようになる

# できなくなること(ユーザ目線)
- 「香りの濃淡：5.0」「味の濃淡：5.0」のような数値テキストの直接表示は見られなくなる（マップ表示に統合）

# 影響範囲
- `app/views/timeline/_sake_log.html.erb` のみ（共通パーシャル・ヘルパーは変更なし）
- タイムライン画面（`/timeline`、ログイン不要で閲覧可能な画面）に影響

# 動作確認とその方法
- [ ] タイムラインの各記録カードに4象限マップが表示される
- [ ] 記録の値に応じて該当する1象限だけが活性化（背景色が濃く・枠線が実線）される
- [ ] `taste = 5.0` / `aroma = 5.0` の境界値の記録が右上（濃い×華やか）になる
- [ ] スマホ幅（md未満）で軸ラベルが非表示になり、PC幅（md以上）で表示される
- [ ] マイログ一覧（#79）とマップのサイズ・配色・表示位置の見え方が揃っている
- [ ] Rubocop・`yarn tailwind:check` が通る

# その他
<!-- 何かあれば -->