### PR TITLE
Feature/82 sake log detail page

### DIFF
--- a/app/controllers/sake_logs_controller.rb
+++ b/app/controllers/sake_logs_controller.rb
@@ -3,6 +3,10 @@ class SakeLogsController < ApplicationController
     @sake_logs = current_user.sake_logs.includes(:sake).order(created_at: :desc)
   end
 
+  def show
+    @sake_log = SakeLog.includes(:user, sake: { brand: { brewery: :area } }).find(params[:id])
+  end
+
   def new
     @form = SakeLogForm.new(user: current_user)
   end
@@ -11,7 +15,7 @@ class SakeLogsController < ApplicationController
     @form = SakeLogForm.new(sake_log_form_params, user: current_user)
 
     if @form.save
-      redirect_to sake_logs_path, success: t("defaults.flash_message.created", item: SakeLog.model_name.human)
+      redirect_to sake_log_path(@form.sake_log), success: t("defaults.flash_message.created", item: SakeLog.model_name.human)
     else
       flash.now[:error] = t("defaults.flash_message.not_created", item: SakeLog.model_name.human) # TODO: ログ出力
       render :new, status: :unprocessable_entity
@@ -28,7 +32,7 @@ class SakeLogsController < ApplicationController
     @form = SakeLogForm.new(sake_log_form_params, user: current_user, sake_log: @sake_log)
 
     if @form.save
-      redirect_to sake_logs_path, success: t("defaults.flash_message.updated", item: SakeLog.model_name.human)
+      redirect_to sake_log_path(@form.sake_log), success: t("defaults.flash_message.updated", item: SakeLog.model_name.human)
     else
       flash.now[:error] = t("defaults.flash_message.not_updated", item: SakeLog.model_name.human) # TODO: ログ出力
       render :edit, status: :unprocessable_entity

--- a/app/helpers/taste_aroma_map_helper.rb
+++ b/app/helpers/taste_aroma_map_helper.rb
@@ -69,4 +69,16 @@ module TasteAromaMapHelper
   def quadrant_map_size_class(size)
     QUADRANT_MAP_SIZES.fetch(size)
   end
+
+  # 点プロット（variant: :plot）で打つ点の位置を style 属性の文字列として返す
+  # 味（横軸）は左から右へ、香り（縦軸）は下から上へ値が大きくなるように配置する。
+  #
+  # @param taste_strength [Float] 味の濃淡（0〜10）
+  # @param aroma_strength [Float] 香りの濃淡（0〜10）
+  # @return [String] style 属性に渡す文字列（例: "left: 30.0%; top: 80.0%;"）
+  def quadrant_plot_point_style(taste_strength, aroma_strength)
+    left_percent = (taste_strength.to_f / SakeLog::TASTE_STRENGTH_MAX * 100).round(1)
+    top_percent = ((1 - aroma_strength.to_f / SakeLog::AROMA_STRENGTH_MAX) * 100).round(1)
+    "left: #{left_percent}%; top: #{top_percent}%;"
+  end
 end

--- a/app/views/sake_logs/_sake_log.html.erb
+++ b/app/views/sake_logs/_sake_log.html.erb
@@ -1,11 +1,12 @@
-<article id="<%= dom_id sake_log %>">
+<article id="<%= dom_id sake_log %>" class="relative">
+  <%= link_to "", sake_log_path(sake_log), class: "absolute inset-0" %>
   <section class="p-2 body">
 
     <%# タイトル %>
     <section class="flex justify-between">
       <h2 class="text-xl font-bold title"><%= sake_log.sake.product_name %></h2>
       <%# 各種ボタン %>
-      <div class="flex gap-2 buttons">
+      <div class="flex relative z-10 gap-2 buttons">
         <% if current_user&.own?(sake_log) %>
           <%# 編集ボタン %>
           <%= link_to edit_sake_log_path(sake_log), id: "button-edit-#{sake_log.id}" do %>

--- a/app/views/sake_logs/show.html.erb
+++ b/app/views/sake_logs/show.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title,  t('.title') %>
+
+<div class="w-full">
+  <%= page_heading %>
+
+  <article id="<%= dom_id @sake_log %>" class="p-2">
+    <%# 投稿者・記録日時 + 各種ボタン %>
+    <section class="flex justify-between items-start">
+      <div>
+        <%# 投稿者 %>
+        <div class="flex gap-1 items-center text-sm text-neutral-500">
+          <span class="material-symbols-rounded ms-size-24">account_circle</span>
+          <span><%= @sake_log.user.name %></span>
+        </div>
+        <%# 記録日時 %>
+        <p class="text-xs text-neutral-500"><%= l @sake_log.created_at, format: :long %></p>
+      </div>
+
+      <div class="flex gap-2 buttons">
+        <% if current_user.own?(@sake_log) %>
+          <%# 編集ボタン %>
+          <%= link_to edit_sake_log_path(@sake_log), id: "button-edit-#{@sake_log.id}" do %>
+            <span class="material-symbols-rounded text-primary ms-size-24">edit_square</span>
+          <% end %>
+          <%# 削除ボタン %>
+          <%= link_to sake_log_path(@sake_log), id: "button-delete-#{@sake_log.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+            <span class="material-symbols-rounded text-primary ms-size-24">delete</span>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+
+    <%# 銘柄名・商品名・蔵元（都道府県） %>
+    <section class="mt-1">
+      <div class="flex flex-wrap gap-x-2 items-baseline">
+        <h2 class="text-2xl font-bold"><%= @sake_log.sake.brand.name %></h2>
+        <p class="text-base"><%= @sake_log.sake.product_name %></p>
+      </div>
+      <p class="mt-1 badge badge-ghost badge-sm">
+        <%= @sake_log.sake.brand.brewery.name %>（<%= @sake_log.sake.brand.brewery.area.name %>）
+      </p>
+    </section>
+
+    <%# 好み度 %>
+    <section class="mt-2">
+      <div class="flex gap-0 items-center">
+        <% SakeLog::RATING_MAX.times do |rate| %>
+          <span class="inline-block w-5 h-5 mask mask-star-2 <%= star_rating_class(rate, @sake_log.rating) %>"></span>
+        <% end %>
+      </div>
+    </section>
+
+    <%# 味 × 香りの4象限マップ（点プロット） %>
+    <section class="flex flex-col items-center my-6">
+      <%= render "shared/taste_aroma_map", taste: @sake_log.taste_strength, aroma: @sake_log.aroma_strength, variant: :plot, size: :lg %>
+      <p class="mt-3 text-xs text-neutral-500">
+        味の濃淡 <%= @sake_log.taste_strength %> ／ 香りの濃淡 <%= @sake_log.aroma_strength %>
+      </p>
+    </section>
+
+    <%# 感想 %>
+    <% if @sake_log.review.present? %>
+      <section class="mt-4">
+        <h3 class="text-sm font-semibold text-neutral-500">感想</h3>
+        <%= simple_format(h(@sake_log.review), class: "py-2") %>
+      </section>
+    <% end %>
+
+    <%# 一覧へ戻るリンク %>
+    <section class="flex justify-center mt-6">
+      <%= link_to "マイログに戻る", sake_logs_path, class: "btn btn-outline btn-primary" %>
+    </section>
+  </article>
+</div>

--- a/app/views/shared/_taste_aroma_map.html.erb
+++ b/app/views/shared/_taste_aroma_map.html.erb
@@ -2,7 +2,7 @@
   locals:
     taste:   味の濃淡の値（SakeLog#taste_strength / Sake#average_taste_strength）
     aroma:   香りの濃淡の値（SakeLog#aroma_strength / Sake#average_aroma_strength）
-    variant: 表示方式（:quadrant = 該当する1象限だけをハイライト）
+    variant: 表示方式（:quadrant = 該当する1象限だけをハイライト / :plot = 全象限を薄く表示し記録値の位置に点を打つ）
     size:    外枠サイズ（省略時 :sm / :md / :lg。呼び出し側は用途名で指定）
     labels:  軸ラベルの表示方式（省略時 :always = 常に表示 / :responsive = スマホで非表示）
   サイズは呼び出し側のラッパー要素の幅で制御する（内部は幅 100% で描画）
@@ -46,6 +46,12 @@
       <polyline points="144,14 150,6 156,14" />
       <polyline points="144,186 150,194 156,186" />
     </svg>
+
+    <%# 記録値の点（variant: :plot のときのみ）
+      style で left / top を % 指定し、translate で点の中心を座標に合わせる %>
+    <% if variant == :plot %>
+      <span class="absolute z-10 w-3 h-3 rounded-full border-2 border-white shadow-md -translate-x-1/2 -translate-y-1/2 bg-primary" style="<%= quadrant_plot_point_style(taste, aroma) %>"></span>
+    <% end %>
   </div>
 
   <%# 右の軸ラベル(縦書き) %>

--- a/app/views/timeline/_sake_log.html.erb
+++ b/app/views/timeline/_sake_log.html.erb
@@ -1,4 +1,6 @@
-<article id="<%= dom_id sake_log %>">
+<article id="<%= dom_id sake_log %>" class="relative">
+  <%= link_to "", sake_log_path(sake_log), class: "absolute inset-0" %>
+
   <section class="p-2 body">
     <%# ユーザー情報 %>
     <section class="flex gap-2">
@@ -9,7 +11,7 @@
         <p class="text-xs text-neutral-500"><%= l sake_log.created_at, format: :long %></p>
       </div>
       <%# 各種ボタン %>
-      <div class="pt-2 ml-auto buttons">
+      <div class="relative z-10 pt-2 ml-auto buttons">
         <% if current_user&.own?(sake_log) %>
           <%# 削除ボタン %>
           <%= link_to sake_log_path(sake_log), id: "button-delete-#{sake_log.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')} do %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,6 +36,8 @@ ja:
       title: 日本酒記録編集
     index:
       title: マイログ
+    show:
+      title: 記録の詳細
     sakenowa_attribution_html: "%{link}を利用しています"
   timeline:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :sake_logs, only: %i[index new create edit update destroy]
+  resources :sake_logs, only: %i[index show new create edit update destroy]
   get "timeline", to: "timeline#index", as: :timeline
 
   # Defines the root path route ("/")


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
日本酒記録の詳細画面を新設し、味 × 香りの4象限マップを **点プロット** で表示する。
あわせて、マイログ・タイムラインの各カードから詳細画面へ遷移する導線を追加した。

# 関連issue
<!-- 閉じたいissue -->
close #82
close #27

# やったこと
<!-- 実施内容を簡潔に -->
- `resources :sake_logs` に `show` を追加
- `SakeLogsController#show` を追加（ログイン必須・銘柄／蔵元／都道府県／投稿者を eager load）
- 記録詳細画面 `app/views/sake_logs/show.html.erb` を新規作成
- 共通パーシャル `shared/_taste_aroma_map` に `variant: :plot`（点プロット）を追加
- `TasteAromaMapHelper#quadrant_plot_point_style`（点の座標計算）を追加
- マイログ・タイムラインの記録カードをストレッチリンク化（カード全体で詳細へ遷移）
- 記録の登録・更新成功時のリダイレクト先を、一覧から詳細画面へ変更
- 辞書に `sake_logs.show.title`（記録の詳細）を追加

# やらないこと
<!-- スコープ外の作業 -->
- なし

# できるようになること(ユーザ目線)
- 記録の詳細を確認できる
- 味 × 香りの位置が「点」で表示され、4象限のどこに位置するかを正確に把握できる
- マイログ・タイムラインのカードのどこをタップしても詳細画面へ遷移できる
- 記録を登録・更新した直後に、その記録の詳細画面で結果を確認できる
- タイムラインから他ユーザーの記録の詳細も閲覧できる

# できなくなること(ユーザ目線)
- 記録の登録・更新後に、マイログ一覧へ戻らなくなった（詳細画面へ遷移するように変更）
- 一覧カード上で感想テキストをドラッグ選択できなくなった
  （カード全体がリンクを覆うストレッチリンクの仕様。詳細画面では選択可能）

# 影響範囲
- **`SakeLogsController`**: `create` / `update` 成功時のリダイレクト先を変更（`sake_logs_path` → `sake_log_path`）
- **`shared/_taste_aroma_map`**: マイログ一覧（#79）・タイムライン一覧（#80）・詳細画面（本 PR）の**3画面で共有**。
  配色や判定を変更する場合は3画面すべての確認が必要
- **記録カード2ファイル**: `sake_logs/_sake_log.html.erb` / `timeline/_sake_log.html.erb` に
  ストレッチリンクを追加。既存の編集・削除ボタンは `relative z-10` で前面に出して従来どおり動作

# 動作確認とその方法
- [x] 記録を新規登録すると詳細画面に遷移し、「日本酒記録を作成しました」が表示される
- [x] 記録を編集・更新すると詳細画面に遷移し、「日本酒記録を更新しました」が表示される
- [x] 詳細画面の削除ボタン → 確認ダイアログ → マイログ一覧に戻る
- [x] マイログのカードのどこをタップしても詳細画面へ遷移する
- [x] タイムラインのカードのどこをタップしても詳細画面へ遷移する
- [x] カード上の編集ボタンを押すと、詳細ではなく編集画面へ遷移する
- [x] カード上の削除ボタンを押すと、詳細に飛ばずに確認ダイアログが出る
- [x] 詳細画面で4象限すべてが薄い色で表示され、記録値の位置に点が1つ表示される
- [x] 味 5.0 / 香り 5.0 の記録は、点が軸の交点（中央）に表示される
- [x] 感想が空の記録では「感想」の見出しごと表示されない
- [x] 他ユーザーの記録の詳細を開くと、編集・削除ボタンが表示されない
- [x] 未ログインで `/sake_logs/:id` を開くとログイン画面にリダイレクトされる

# その他
<!-- 何かあれば -->
- **点の座標計算**は Tailwind のクラスではなく `style` 属性で指定している。
  Tailwind はビルド時にクラスを生成する仕組みのため、実行時に決まる `left: 64%` のような値を扱えないため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 日本酒記録の詳細ページを追加しました。
  - 銘柄情報、評価、感想、投稿者、味・香りの4象限マップを確認できます。
  - 4象限マップ上に味・香りの記録位置を表示します。
  - 一覧やタイムラインの記録全体をクリックして詳細へ移動できます。
  - APIで日本酒記録の詳細取得に対応しました。

- **改善**
  - 記録の作成・更新後、対象記録の詳細ページへ移動するようになりました。
  - 詳細ページから一覧へ戻れるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->