### PR TITLE
Feature/292 timeline infinite scroll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,8 @@ gem "devise-i18n"
 gem "meta-tags"
 gem "sitemap_generator"
 
-
+# ページネーション
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.21.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -459,6 +471,7 @@ DEPENDENCIES
   inline_svg
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   pg (~> 1.6)
   pry

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -5,5 +5,8 @@ class TimelinesController < ApplicationController
     @sake_logs = SakeLog.includes(:user, sake: { brand: { brewery: :area } })
                         .with_attached_images
                         .order(created_at: :desc, id: :desc)
+                        .page(params[:page])
+
+    render :page if turbo_frame_request?
   end
 end

--- a/app/views/timelines/_next_page_frame.html.erb
+++ b/app/views/timelines/_next_page_frame.html.erb
@@ -1,0 +1,19 @@
+<%# 次ページ読み込み用の Turbo Frame
+  locals:
+    sake_logs: kaminari でページングされた記録（next_page を持つ）
+
+  【class を付けている理由】
+  turbo-frame 要素は既定で display: inline のため、そのままだとカードが横に並んでしまう。
+  親の #timeline と同じ flex-col / divide-y を指定して、カードの積み方と区切り線を揃える。
+%>
+<% if sake_logs.next_page %>
+  <%= turbo_frame_tag "timeline_page_#{sake_logs.next_page}",
+        src: timeline_path(page: sake_logs.next_page),
+        loading: :lazy,
+        class: "flex flex-col gap-0 divide-y" do %>
+    <%# 読み込み中に表示される中身。読み込みが終わると、次ページの内容ごと置き換わる %>
+    <div class="flex justify-center py-6">
+      <span class="loading loading-dots loading-md text-primary"></span>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -5,6 +5,7 @@
   <div id="timeline" class="flex flex-col gap-0 divide-y">
     <% if @sake_logs.any? %>
       <%= render partial: 'timelines/sake_log', collection: @sake_logs %>
+      <%= render 'timelines/next_page_frame', sake_logs: @sake_logs %>
     <% else %>
       <p class="my-10 text-center">まだ投稿がありません</p>
     <% end %>

--- a/app/views/timelines/page.html.erb
+++ b/app/views/timelines/page.html.erb
@@ -1,0 +1,11 @@
+<%# 2ページ目以降のカードを返すテンプレート
+
+  【なぜ turbo_frame_tag で包むのか】
+  Turbo は返ってきた HTML の中から「リクエスト元の frame と同じ id を持つ frame」を探し、
+  その中身だけを差し替える。id が一致しないと "Content missing" になってしまう。
+%>
+<%= turbo_frame_tag "timeline_page_#{@sake_logs.current_page}",
+      class: "flex flex-col gap-0 divide-y" do %>
+  <%= render partial: "timelines/sake_log", collection: @sake_logs %>
+  <%= render "timelines/next_page_frame", sake_logs: @sake_logs %>
+<% end %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
# 概要
タイムラインを無限スクロールに対応させ、Issue #292 を完了する。
Turbo Frame の遅延読み込みを使い、JavaScript を書かずにスクロールで次のページを読み込む。

# 関連issue
close #292

# やったこと
- kaminari を導入し、1ページあたり 10 件に設定（`config/initializers/kaminari_config.rb`）
- `TimelinesController#index` に `page(params[:page])` を追加
- `loading: "lazy"` の Turbo Frame を一覧の末尾に配置（`_next_page_frame.html.erb`）
- 2ページ目以降は `turbo_frame_request?` で判定し、画面全体ではなく追加ぶんのカードだけを返す（`page.html.erb`）

# やらないこと
- マイログ一覧の無限スクロール化（`sake_logs#index` は従来どおり全件表示）
- ページ番号リンク（「1 2 3 … 次へ」）の表示 → 無限スクロールのため不要
- 記録詳細画面のレイアウト刷新、コメント・いいね・シェア機能、TOP ページ → 別 Issue

# できるようになること(ユーザ目線)
- タイムラインを下にスクロールすると、次の 10 件が自動で読み込まれる
- ページ遷移が起きないため、スクロール位置が保たれたまま読み進められる
- 初回表示が 10 件に絞られ、投稿が増えても表示が重くならない

# できなくなること(ユーザ目線)
- なし（既存の操作はすべてそのまま）

# 影響範囲
- タイムライン（`/timeline`、ログイン時のルートページ）
- マイログ一覧・記録詳細画面への影響なし

# 動作確認とその方法
- [x] スクロールすると次のページが自動で読み込まれる
- [x] 読み込み時にページ遷移が起きず、スクロール位置が保たれる
- [x] 読み込んだカードが横並びにならず、区切り線も表示される（`<turbo-frame>` の class 指定の確認）
- [x] 最終ページまで読み込むと、それ以上リクエストが飛ばない
- [x] 記録が 1 ページに収まる件数のときはスピナーが表示されない
- [x] 未ログインでもスクロールで次のページが読み込まれる
- [x] 2 ページ目以降のカードでも削除するとそのカードだけが消える
- [x] Rubocop / Brakeman / `yarn tailwind:check` が通る

# その他
## Turbo Frame の入れ子について
次ページを読み込むたびに `<turbo-frame>` が一段ネストする。Turbo Frame 方式では正常な挙動で、実用上の問題はない。
